### PR TITLE
Add polymorphic relationship for CacheKey. Update Fluent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,12 +265,7 @@ See: [Usage and Examples](docs/en/examples.md)
 
 ## Fluent support
 
-If you are using Silverstripe Framework >= 4.7, then you're already good to go. `CacheKey::generateKeyHash()` uses
-`DataObject::getUniqueKey()`, and Fluent considerations are already covered by this method.
-
-If you are using Silverstripe Framework <= 4.6, then you will need to supplement the key hash that we generate by
-implementing a method on your class (or in an extension) called `updateGenerateKeyHash()`. You will want to add any
-relevant Locale codes as part of this.
+See: [Fluent support](docs/en/fluent.md)
 
 ## Performance impact/considerations
 

--- a/docs/en/fluent.md
+++ b/docs/en/fluent.md
@@ -1,0 +1,64 @@
+# Fluent support
+
+* [Localising your Partial Cache](#localising-your-partial-cache)
+    * [Use configuration (ideal)](#use-configuration-ideal)
+    * [Use extension (less ideal, but still fine)](#use-extension-less-ideal-but-still-fine)
+    * [Add it to your Partial Cache manually](#add-it-to-your-partial-cache-manually)
+
+We have considered Fluent for this module, however, the level of configuration available in Fluent makes it difficult
+for us to prescribe a solution at this time.
+
+Fluent itself provides us with the mechanism we require to have a separate cache for each frontend Locale that our users
+browse, however, it is important to note that with our "out of the box" implementation, when any Localisation for
+a `DataObject` is updated, it will invalidate the cache for **all** Localisations of that particular `DataObject`.
+
+This does mean that you will be invalidating the cache for Locales that might not have been updated, but we feel that
+this is acceptable in these early stages of this module's life. The important thing is that the caches **will be
+unique** for each Locale that your users browse, and you **will not** have data "leak" from one Locale to another.
+
+## Localising your Partial Cache
+
+This is not specific to Keys for Cache, and is generally recommended for any project using Fluent.
+
+When you are creating your `<% cached %>` wrappers, you will want to make sure that your `CurrentLocale` is appended to
+the Key. This is to make sure that you don't ever serve the cache from another Locale accidentally (in the same way that
+Silvesrtripe automatically appends your current `Stage` to the Key so that you never serve draft content in live).
+
+There are a couple of ways that we can achieve this.
+
+### Use configuration (ideal)
+
+```yaml
+SilverStripe\View\SSViewer:
+    global_key: '$CurrentReadingMode, $CurrentUser.ID, $CurrentLocale'
+```
+
+`SSViewer` already has configuration available called `global_key`. The default value is:
+`$CurrentReadingMode, $CurrentUser.ID`
+
+Fluent provides us with a template variable `$CurrentLocale`, so we can simply add this to the `global_key`.
+
+### Use extension (less ideal, but still fine)
+
+```yaml
+SilverStripe\ORM\DataObject:
+    extensions:
+        FluentExtensions: Terraformers\KeysForCache\Extensions\FluentExtension
+```
+
+We have provided a very basic `FluentExtension` which you can apply. This extension implements the `updateCacheKey()`
+method so that any usages of `getCacheKey()` or `$CacheKey` will have your current Locale appended to it.
+
+You could decide to only apply this to certain classes, if you would prefer.
+
+This is less ideal than using the config purely because it's slightly slower.
+
+### Add it to your Partial Cache manually
+
+```silverstripe
+<% cached $CacheKey, $CurrentLocale %>
+    ...
+<% end_cached %>
+```
+
+You can also implement `$CurrentLocale` in your `cached` wrappers yourself when you need it.

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -5,6 +5,7 @@ namespace Terraformers\KeysForCache\Extensions;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
 use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\DataTransferObjects\CacheKeyDto;
 use Terraformers\KeysForCache\Models\CacheKey;
@@ -13,9 +14,14 @@ use Terraformers\KeysForCache\Services\StageCacheProcessingService;
 
 /**
  * @property DataObject|$this $owner
+ * @method HasManyList|CacheKey CacheKeys()
  */
 class CacheKeyExtension extends DataExtension
 {
+    private static array $has_many = [
+        'CacheKeys' => CacheKey::class . '.Record',
+    ];
+
     public function findCacheKeyHash(): ?string
     {
         if (!$this->owner->isInDB()) {
@@ -84,7 +90,7 @@ class CacheKeyExtension extends DataExtension
         // Versioned (the changes should be seen immediately even though the object wasn't Published)
         $publishUpdates = !$this->owner->hasExtension(Versioned::class);
         $this->triggerEvent();
-        CacheKey::remove($this->owner->getClassName(), $this->owner->ID);
+        CacheKey::remove($this->owner);
     }
 
     public function onAfterPublish(): void

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -19,6 +19,9 @@ use Terraformers\KeysForCache\Services\StageCacheProcessingService;
 class CacheKeyExtension extends DataExtension
 {
     private static array $has_many = [
+        // Programmatically we know that we will only ever create one of these CacheKey records per unique DataObject,
+        // however, there is no unique index on CacheKey, and Silverstripe requires that our polymorphic relationships
+        // be defined in this way (because a has_many will technically be possible, from a data integrety p.o.v.)
         'CacheKeys' => CacheKey::class . '.Record',
     ];
 

--- a/src/Extensions/FluentExtension.php
+++ b/src/Extensions/FluentExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Terraformers\KeysForCache\Extensions;
+
+use SilverStripe\ORM\DataExtension;
+use Terraformers\KeysForCache\DataTransferObjects\CacheKeyDto;
+use TractorCow\Fluent\State\FluentState;
+
+class FluentExtension extends DataExtension
+{
+    public function updateCacheKey(CacheKeyDto $cacheKey): void
+    {
+        // You aren't using Fluent, so we can't append any Locale to your cache key
+        if (!class_exists(FluentState::class)) {
+            return;
+        }
+
+        $currentLocale = FluentState::singleton()->getLocale();
+
+        // There is no current Locale for us to append
+        if (!$currentLocale) {
+            return;
+        }
+
+        $cacheKey->appendKey($currentLocale);
+    }
+}

--- a/tests/Extensions/CacheKeyExtensionTest.yml
+++ b/tests/Extensions/CacheKeyExtensionTest.yml
@@ -1,23 +1,4 @@
-#Page:
-#  page1:
-#    Title: Page 1
-#
-#App\Models\MenuGroup:
-#  group1:
-#    Title: Group 1
-#  group2:
-#    Title: Group 2
-#
-#App\Models\MenuItem:
-#  item1:
-#    Title: Item 1
-#    MenuGroup: =>App\Models\MenuGroup.group1
-#  item2:
-#    Title: Item 2
-#    MenuGroup: =>App\Models\MenuGroup.group1
-#  item3:
-#    Title: Item 1
-#    MenuGroup: =>App\Models\MenuGroup.group2
-#  item4:
-#    Title: Item 2
-#    MenuGroup: =>App\Models\MenuGroup.group2
+# Creation of a Page will itself generate a CacheKey
+Terraformers\KeysForCache\Tests\Mocks\CachePage:
+  page1:
+    Title: Page 1


### PR DESCRIPTION
We were essentially already using a polymorphic relationship, just without the official config.

I don't know if it will, but if we eventually do go down the route of adding more Fluent support, having the correct polymorphic relationship **might** be useful. At this stage, it doesn't hurt to have it.