### PR TITLE
Don't track edges from. Rely on alreadyProcessed instead

### DIFF
--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -5,7 +5,6 @@ namespace Terraformers\KeysForCache\RelationshipGraph;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\DataObject;
 
 class Graph


### PR DESCRIPTION
If we track `$from` in this way, then configurations like below often do not trigger an invalidation.

```php
class SiteConfigExtensions extends DataExtension
{
    private static array $has_one = [
        'FacebookLink' => Link::class,
        'InstagramLink' => Link::class,
    ];

    private static array $cares = [
        'FacebookLink' => Link::class,
        'InstagramLink' => Link::class,
    ];
}
```

If we update our `InstagramLink`, then there is a chance that the first `Edge` we attempt to update is `$from: Link, $to: SiteConfig, $relation: FacebookLink`.

`updateEdge()` will end up processing an empty `DataList` as it filters `SiteConfig` on its `FacebookLinkID` field. We then mark the `Edge` as processed, so we don't "try again" when we get to `InstagramLink`.

I think `alreadyProcessed()` is the mechanism that we want to rely on to make sure that we don't update the same instance more than once, but we should follow any/all `Edges` until we do find an active relationship path.