### PR TITLE
Increase code coverage. Fixes #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,10 @@ version: ~> 1.0
 import:
   - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
 
-env:
-  global:
-    - REQUIRE_RECIPE="4.x-dev"
-
 jobs:
-  fast_finish: true
   include:
     - php: 7.4
       env:
         - DB=MYSQL
-        - REQUIRE_INSTALLER="$REQUIRE_RECIPE"
+        - REQUIRE_INSTALLER="4.x-dev"
         - PHPUNIT_TEST=1

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.4",
-        "silverstripe/framework": "^4",
-        "symfony/event-dispatcher": "^5.3"
+        "silverstripe/framework": "^4.6"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7",

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -4,6 +4,8 @@ namespace Terraformers\KeysForCache\Extensions;
 
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordViewer;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
@@ -28,13 +30,23 @@ class CacheKeyExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields): void
     {
-        if ($this->owner->config()->get('remove-cache-keys-field')) {
-            $fields->removeByName('CacheKeys');
+        // Field is initially a GridField (with too many options) within a Tab. We don't want that
+        $fields->removeByName([
+            'CacheKeys',
+        ]);
+
+        if (!$this->owner->config()->get('enable-cache-keys-field')) {
+            return;
         }
 
         if (!$this->owner->config()->get('has_cache_key')) {
-            $fields->removeByName('CacheKeys');
+            return;
         }
+
+        $fields->addFieldToTab(
+            'Root.Settings',
+            GridField::create('CacheKeys', 'Cache Keys', $this->owner->CacheKeys(), GridFieldConfig_RecordViewer::create())
+        );
     }
 
     public function getCacheKey(): ?string

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -28,37 +28,13 @@ class CacheKeyExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields): void
     {
-        if (!$this->owner->config()->get('remove-cache-keys-field')) {
-            return;
+        if ($this->owner->config()->get('remove-cache-keys-field')) {
+            $fields->removeByName('CacheKeys');
         }
 
-        $fields->removeByName('CacheKeys');
-    }
-
-    public function findCacheKeyHash(): ?string
-    {
-        if (!$this->owner->isInDB()) {
-            return null;
+        if (!$this->owner->config()->get('has_cache_key')) {
+            $fields->removeByName('CacheKeys');
         }
-
-        $hasCacheKey = $this->owner->config()->get('has_cache_key');
-
-        if (!$hasCacheKey) {
-            return null;
-        }
-
-        // Update or create (in this case, it will be create)
-        $cacheKey = CacheKey::findOrCreate($this->owner);
-
-        if (!$cacheKey->isPublished()) {
-            // If the owner is not Versioned, or if it has been published, then we want to make sure we publish our
-            // CacheKey at the same time
-            if (!$this->owner->hasExtension(Versioned::class) || $this->owner->isPublished()) {
-                $cacheKey->publishRecursive();
-            }
-        }
-
-        return $cacheKey->KeyHash;
     }
 
     public function getCacheKey(): ?string
@@ -68,21 +44,6 @@ class CacheKeyExtension extends DataExtension
         $this->owner->invokeWithExtensions('updateCacheKey', $key);
 
         return $key->getKey();
-    }
-
-    protected function triggerEvent(bool $publishUpdates = false): void
-    {
-        $blacklist = Config::forClass(CacheKey::class)->get('blacklist');
-
-        if (in_array($this->owner->ClassName, $blacklist)) {
-            return;
-        }
-
-        $service = $publishUpdates
-            ? LiveCacheProcessingService::singleton()
-            : StageCacheProcessingService::singleton();
-
-        $service->processChange($this->owner);
     }
 
     /**
@@ -114,5 +75,46 @@ class CacheKeyExtension extends DataExtension
     public function onAfterUnpublish(): void
     {
         $this->triggerEvent(true);
+    }
+
+    protected function triggerEvent(bool $publishUpdates = false): void
+    {
+        $blacklist = Config::forClass(CacheKey::class)->get('blacklist');
+
+        if (in_array($this->owner->ClassName, $blacklist)) {
+            return;
+        }
+
+        $service = $publishUpdates
+            ? LiveCacheProcessingService::singleton()
+            : StageCacheProcessingService::singleton();
+
+        $service->processChange($this->owner);
+    }
+
+    protected function findCacheKeyHash(): ?string
+    {
+        if (!$this->owner->isInDB()) {
+            return null;
+        }
+
+        $hasCacheKey = $this->owner->config()->get('has_cache_key');
+
+        if (!$hasCacheKey) {
+            return null;
+        }
+
+        // Update or create (in this case, it will be create)
+        $cacheKey = CacheKey::findOrCreate($this->owner);
+
+        if (!$cacheKey->isPublished()) {
+            // If the owner is not Versioned, or if it has been published, then we want to make sure we publish our
+            // CacheKey at the same time
+            if (!$this->owner->hasExtension(Versioned::class) || $this->owner->isPublished()) {
+                $cacheKey->publishRecursive();
+            }
+        }
+
+        return $cacheKey->KeyHash;
     }
 }

--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -99,7 +99,7 @@ class CacheKey extends DataObject
         }
     }
 
-    public static function generateKeyHash(DataObject $dataObject): string
+    protected static function generateKeyHash(DataObject $dataObject): string
     {
         // getUniqueKey() has only been around since 4.7, but ideally this is what we would like to use as the base for
         // our KeyHash

--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -25,13 +25,20 @@ class Graph
     {
         return array_filter(
             $this->edges,
-            fn($e) => $e->getFromClassName() === $from
+            fn(Edge $e) => $e->getFromClassName() === $from
         );
     }
 
     public function getGlobalCares(): array
     {
         return $this->global_cares;
+    }
+
+    public function flush(): void
+    {
+        $this->nodes = [];
+        $this->edges = [];
+        $this->global_cares = [];
     }
 
     private function addNode(Node $node): self
@@ -65,6 +72,13 @@ class Graph
         return $this;
     }
 
+    private function getClassAndRelation(string $input): array
+    {
+        $res = explode('.', $input);
+
+        return [$res[0], $res[1] ?? null];
+    }
+
     private function build(): void
     {
         // Relations only exist from data objects
@@ -86,7 +100,7 @@ class Graph
 
                     // Has many exists for the relation
                     if (array_key_exists($relation, $hasMany)) {
-                        $hasOnes = Config::forClass($careClassName)->get('has_one');
+                        $hasOnes = Config::forClass($touchClassName)->get('has_one');
 
                         foreach ($hasOnes as $hasOneRelation => $hasOneClassName) {
                             if ($hasOneClassName !== $className) {
@@ -167,12 +181,5 @@ class Graph
         );
 
         $this->global_cares = $classes;
-    }
-
-    private function getClassAndRelation(string $input): array
-    {
-        $res = explode('.', $input);
-
-        return [$res[0], $res[1] ?? null];
     }
 }

--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -35,7 +35,6 @@ abstract class CacheProcessingService
         while (count($edgesToUpdate) > 0) {
             /** @var EdgeUpdateDto $current */
             $current = array_pop($edgesToUpdate);
-            $from = $current->getEdge()->getFromClassName();
 
             $edgesToUpdate = array_merge(
                 $edgesToUpdate,
@@ -95,6 +94,13 @@ abstract class CacheProcessingService
         }
 
         if ($relation === 'has_one') {
+            $idValue = $instance->getField($edge->getRelation().'ID');
+
+            // A relationship field does exist here, but there is no relationship active
+            if (!$idValue) {
+                return [];
+            }
+
             if ($this->alreadyProcessed($edge->getToClassName(), $instance->getField($edge->getRelation().'ID'))) {
                 return [];
             }

--- a/src/Services/ProcessedUpdatesService.php
+++ b/src/Services/ProcessedUpdatesService.php
@@ -11,6 +11,11 @@ class ProcessedUpdatesService
 
     private array $processedUpdates = [];
 
+    public function flush(): void
+    {
+        $this->processedUpdates = [];
+    }
+
     public function getProcessedUpdates(): array
     {
         return $this->processedUpdates;

--- a/tests/Extensions/CacheKeyExtensionTest.php
+++ b/tests/Extensions/CacheKeyExtensionTest.php
@@ -2,11 +2,11 @@
 
 namespace Terraformers\KeysForCache\Tests\Extensions;
 
-use App\Models\MenuGroup;
-use App\Models\MenuItem;
 use SilverStripe\Dev\SapphireTest;
 use Terraformers\KeysForCache\Models\CacheKey;
+use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\CachePage;
+use Terraformers\KeysForCache\Tests\Mocks\GlobalCaresPage;
 use Terraformers\KeysForCache\Tests\Mocks\NoCachePage;
 
 class CacheKeyExtensionTest extends SapphireTest
@@ -44,6 +44,80 @@ class CacheKeyExtensionTest extends SapphireTest
 
         // There shouldn't be any
         $this->assertCount(0, $keys);
+    }
+
+    public function testPublishUpdatesCacheKey(): void
+    {
+        $parent = $this->objFromFixture(CachePage::class, 'page1');
+        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
+
+        $childKey = $child->getCacheKey();
+
+        $this->assertNotNull($childKey);
+        $this->assertNotEmpty($childKey);
+
+        $parent->forceChange();
+        $parent->publishRecursive();
+
+        $this->assertNotEquals($childKey, $child->getCacheKey());
+    }
+
+    public function testUnpublishUpdatesCacheKey(): void
+    {
+        $parent = $this->objFromFixture(CachePage::class, 'page1');
+        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
+
+        $parent->forceChange();
+        $parent->publishRecursive();
+
+        $childKey = $child->getCacheKey();
+
+        $this->assertNotNull($childKey);
+        $this->assertNotEmpty($childKey);
+
+        ProcessedUpdatesService::singleton()->flush();
+
+        $parent->doUnpublish();
+
+        $this->assertNotEquals($childKey, $child->getCacheKey());
+    }
+
+    public function testDeleteUpdatesCacheKey(): void
+    {
+        $parent = $this->objFromFixture(CachePage::class, 'page1');
+        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
+
+        $childKey = $child->getCacheKey();
+
+        $this->assertNotNull($childKey);
+        $this->assertNotEmpty($childKey);
+
+        $parent->doArchive();
+
+        $this->assertNotEquals($childKey, $child->getCacheKey());
+    }
+
+    public function testGetCacheKey(): void
+    {
+        // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
+        $page = CachePage::create();
+        $page->write();
+
+        // Fetch all CacheKeys for this ClassName and ID
+        $keys = CacheKey::get()->filter([
+            'RecordClass' => $page->ClassName,
+            'RecordID' => $page->ID,
+        ]);
+
+        // There should be exactly 1
+        $this->assertCount(1, $keys);
+
+        /** @var CacheKey $key */
+        $key = $keys->first();
+        $pageKey = $page->getCacheKey();
+
+        $this->assertNotNull($pageKey);
+        $this->assertEquals($key->KeyHash, $pageKey);
     }
 
 }

--- a/tests/Extensions/CacheKeyExtensionTest.yml
+++ b/tests/Extensions/CacheKeyExtensionTest.yml
@@ -2,3 +2,7 @@
 Terraformers\KeysForCache\Tests\Mocks\CachePage:
   page1:
     Title: Page 1
+
+Terraformers\KeysForCache\Tests\Mocks\GlobalCaresPage:
+  page1:
+    Title: Global Cares Page 1

--- a/tests/Mocks/CaresPage.php
+++ b/tests/Mocks/CaresPage.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Mocks;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
 use Page;
 use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
@@ -9,7 +10,11 @@ use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
 /**
  * @mixin CacheKeyExtension
  */
-class CachePage extends Page implements TestOnly
+class CaresPage extends Page implements TestOnly
 {
     private static bool $has_cache_key = true;
+
+    private static array $cares = [
+        'Parent' => SiteTree::class,
+    ];
 }

--- a/tests/Mocks/GlobalCaresPage.php
+++ b/tests/Mocks/GlobalCaresPage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+use Page;
+use SilverStripe\SiteConfig\SiteConfig;
+use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
+
+/**
+ * @mixin CacheKeyExtension
+ */
+class GlobalCaresPage extends Page implements TestOnly
+{
+    private static bool $has_cache_key = true;
+
+    private static array $global_cares = [
+        'SiteTree' => SiteTree::class,
+        'SiteConfig' => SiteConfig::class,
+    ];
+}

--- a/tests/Mocks/NoCachePage.php
+++ b/tests/Mocks/NoCachePage.php
@@ -4,7 +4,11 @@ namespace Terraformers\KeysForCache\Tests\Mocks;
 
 use SilverStripe\Dev\TestOnly;
 use Page;
+use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
 
+/**
+ * @mixin CacheKeyExtension
+ */
 class NoCachePage extends Page implements TestOnly
 {
     private static bool $has_cache_key = false;

--- a/tests/Mocks/TouchesPage.php
+++ b/tests/Mocks/TouchesPage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+use Page;
+use SilverStripe\SiteConfig\SiteConfig;
+use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
+
+/**
+ * @mixin CacheKeyExtension
+ */
+class TouchesPage extends Page implements TestOnly
+{
+    private static bool $has_cache_key = false;
+
+    private static array $touches = [
+        'SiteConfig' => SiteConfig::class,
+        'Parent' => SiteTree::class,
+    ];
+}

--- a/tests/RelationshipGraph/GraphTest.php
+++ b/tests/RelationshipGraph/GraphTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\RelationshipGraph;
+
+use ReflectionClass;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SiteConfig\SiteConfig;
+use Terraformers\KeysForCache\RelationshipGraph\Edge;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
+use Terraformers\KeysForCache\RelationshipGraph\Node;
+use Terraformers\KeysForCache\Tests\Mocks\CachePage;
+use Terraformers\KeysForCache\Tests\Mocks\CaresPage;
+use Terraformers\KeysForCache\Tests\Mocks\GlobalCaresPage;
+use Terraformers\KeysForCache\Tests\Mocks\NoCachePage;
+use Terraformers\KeysForCache\Tests\Mocks\TouchesPage;
+
+class GraphTest extends SapphireTest
+{
+    public function testAddGetNode(): void
+    {
+        $graph = Graph::singleton();
+        $graph->flush();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $add = $reflectionClass->getMethod('addNode');
+        $add->setAccessible(true);
+        $get = $reflectionClass->getMethod('getNode');
+        $get->setAccessible(true);
+
+        $node = new Node(CachePage::class);
+
+        $add->invoke($graph, $node);
+
+        $node = $get->invoke($graph, CachePage::class);
+
+        $this->assertInstanceOf(Node::class, $node);
+        $this->assertEquals(CachePage::class, $node->getClassName());
+    }
+
+    public function testAddGetNodeNull(): void
+    {
+        $graph = Graph::singleton();
+        $graph->flush();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $add = $reflectionClass->getMethod('addNode');
+        $add->setAccessible(true);
+        $get = $reflectionClass->getMethod('getNode');
+        $get->setAccessible(true);
+
+        $node = new Node(CachePage::class);
+
+        $add->invoke($graph, $node);
+
+        $this->assertNull($get->invoke($graph, NoCachePage::class));
+    }
+
+    public function testAddGetEdge(): void
+    {
+        $graph = Graph::singleton();
+        $graph->flush();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $add = $reflectionClass->getMethod('addEdge');
+        $add->setAccessible(true);
+        $get = $reflectionClass->getMethod('getEdges');
+        $get->setAccessible(true);
+
+        $fromNode = new Node(SiteTree::class);
+        $to = new Node(CaresPage::class);
+
+        $edge = new Edge($fromNode, $to, 'Parent');
+
+        $add->invoke($graph, $edge);
+
+        /** @var Edge $edge */
+        $edges = $get->invoke($graph, SiteTree::class);
+
+        $this->assertCount(1, $edges);
+
+        $edge = array_pop($edges);
+
+        $this->assertInstanceOf(Edge::class, $edge);
+        $this->assertEquals(SiteTree::class, $edge->getFromClassName());
+        $this->assertEquals(SiteTree::class, $edge->getFromClassName());
+    }
+
+    public function testAddGetEdgeNull(): void
+    {
+        $graph = Graph::singleton();
+        $graph->flush();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $add = $reflectionClass->getMethod('addEdge');
+        $add->setAccessible(true);
+        $get = $reflectionClass->getMethod('getEdges');
+        $get->setAccessible(true);
+
+        $fromNode = new Node(SiteTree::class);
+        $to = new Node(CaresPage::class);
+
+        $edge = new Edge($fromNode, $to, 'Parent');
+
+        $add->invoke($graph, $edge);
+
+        /** @var Edge $edge */
+        $edges = $get->invoke($graph, CaresPage::class);
+
+        $this->assertCount(0, $edges);
+    }
+
+    public function testFindOrCreateNode(): void
+    {
+        $graph = Graph::singleton();
+        $graph->flush();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $find = $reflectionClass->getMethod('findOrCreateNode');
+        $find->setAccessible(true);
+        $get = $reflectionClass->getMethod('getNode');
+        $get->setAccessible(true);
+
+        $find->invoke($graph, CachePage::class);
+
+        $node = $get->invoke($graph, CachePage::class);
+
+        $this->assertInstanceOf(Node::class, $node);
+        $this->assertEquals(CachePage::class, $node->getClassName());
+    }
+
+    public function testGetClassAndRelation(): void
+    {
+        $graph = Graph::singleton();
+
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $method = $reflectionClass->getMethod('getClassAndRelation');
+        $method->setAccessible(true);
+
+        $single = CachePage::class;
+        $both = sprintf('%s.Relationship', CachePage::class);
+
+        [$className, $relationship] = $method->invoke($graph, $single);
+
+        $this->assertEquals(CachePage::class, $className);
+        $this->assertNull($relationship);
+
+        [$className, $relationship] = $method->invoke($graph, $both);
+
+        $this->assertEquals(CachePage::class, $className);
+        $this->assertEquals('Relationship', $relationship);
+    }
+
+    public function testGetEdges(): void
+    {
+        $graph = Graph::singleton();
+
+        $expected = [
+            CaresPage::class,
+        ];
+        $result = array_map(
+            function(Edge $edge) {
+                return $edge->getToClassName();
+            },
+            $graph->getEdges(SiteTree::class)
+        );
+
+        $this->assertEquals($expected, $result, '', 0.0, 10, true);
+
+        $expected = [
+            SiteConfig::class,
+            SiteTree::class,
+        ];
+        $result = array_map(
+            fn(Edge $edge) => $edge->getToClassName(),
+            $graph->getEdges(TouchesPage::class)
+        );
+
+        $this->assertEquals($expected, $result, '', 0.0, 10, true);
+    }
+
+    public function testGetGlobalCares(): void
+    {
+        $graph = Graph::singleton();
+        $globalCares = $graph->getGlobalCares();
+
+        $this->assertCount(2, $globalCares);
+
+        $siteConfigClears = $globalCares[SiteConfig::class] ?? null;
+        $siteTreeClears = $globalCares[SiteTree::class] ?? null;
+
+        $this->assertNotNull($siteConfigClears);
+        $this->assertNotNull($siteTreeClears);
+
+        $this->assertCount(1, $siteConfigClears);
+        $this->assertCount(1, $siteTreeClears);
+
+        $this->assertEquals(GlobalCaresPage::class, array_pop($siteConfigClears));
+        $this->assertEquals(GlobalCaresPage::class, array_pop($siteTreeClears));
+    }
+}


### PR DESCRIPTION
* Added some `flush()` methods to our singletons to make our unit testing life a bit easier.
* Made a few methods private/protected as they only had internal usage. Chose `protected` if I felt devs might extend the class, `private` if I thought extension was unlikely.
* Mostly I've left comments in the `Files changed`.

Checklist of tests #9 

Not saying I have 100% cov, but there's at least some level of testing.