### PR TITLE
Replace fn() calls with function() and test code cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ jobs:
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="4.x-dev"
-        - PHPUNIT_TEST=1
+        - PHPUNIT_COVERAGE_TEST=1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+comment: false
+codecov:
+  token: 197eb3dd-03d1-41a7-af34-bcfd41aede6a

--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -25,7 +25,9 @@ class Graph
     {
         return array_filter(
             $this->edges,
-            fn(Edge $e) => $e->getFromClassName() === $from
+            function (Edge $e) use ($from) {
+                return $e->getFromClassName() === $from;
+            }
         );
     }
 
@@ -155,13 +157,17 @@ class Graph
         $classes = ClassInfo::getValidSubClasses(DataObject::class);
 
         $classes = array_map(
-            fn($c) => ['className' => $c, 'cares' => Config::forClass($c)->get('global_cares')],
+            function ($c) {
+                return ['className' => $c, 'cares' => Config::forClass($c)->get('global_cares')];
+            },
             $classes
         );
 
         $classes = array_filter(
             $classes,
-            fn($c) => is_array($c['cares']) && count($c['cares']) > 0
+            function ($c) {
+                return is_array($c['cares']) && count($c['cares']) > 0;
+            }
         );
 
         $classes = array_reduce(

--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -169,7 +169,9 @@ abstract class CacheProcessingService
         }
 
         return array_map(
-            fn($e) => new EdgeUpdateDto($e, $instance),
+            function ($e) use ($instance) {
+                return new EdgeUpdateDto($e, $instance);
+            },
             $applicableEdges
         );
     }
@@ -195,13 +197,20 @@ abstract class CacheProcessingService
 
     private function processGlobalCares(string $className): void
     {
-        $cares = $this->getGraph()->getGlobalCares();
+        $globalCares = $this->getGraph()->getGlobalCares();
         $possibleClassNames = ClassInfo::ancestry($className);
         $cares = array_map(
-            fn($c) => $cares[$c] ?? null,
+            function ($c) use ($globalCares) {
+                return $globalCares[$c] ?? null;
+            },
             $possibleClassNames,
         );
-        $cares = array_filter($cares, fn($c) => !is_null($c));
+        $cares = array_filter(
+            $cares,
+            function ($c) {
+                return !is_null($c);
+            }
+        );
         $cares = array_merge(...array_values($cares));
         $cares = array_unique($cares);
 

--- a/tests/RelationshipGraph/GraphTest.php
+++ b/tests/RelationshipGraph/GraphTest.php
@@ -172,7 +172,9 @@ class GraphTest extends SapphireTest
             SiteTree::class,
         ];
         $result = array_map(
-            fn(Edge $edge) => $edge->getToClassName(),
+            function (Edge $edge) {
+                return $edge->getToClassName();
+            },
             $graph->getEdges(TouchesPage::class)
         );
 


### PR DESCRIPTION
It was suggested that the errors we're seeing when code cov is enabled could be related to us using the `fn()` feature of PHP 7.4 (because our version of PHPUnit is very old).

Let's see!