### PR TITLE
Improvement: Add Cache layer to Graph::build steps

### DIFF
--- a/_config/blacklist.yml
+++ b/_config/blacklist.yml
@@ -1,10 +1,6 @@
 ---
-Name: keysforcache
+Name: kfc-blacklist
 ---
-SilverStripe\ORM\DataObject:
-  extensions:
-    CacheKeyExtension: Terraformers\KeysForCache\Extensions\CacheKeyExtension
-
 Terraformers\KeysForCache\Models\CacheKey:
   blacklist:
     CacheKey: Terraformers\KeysForCache\Models\CacheKey

--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -1,0 +1,8 @@
+---
+Name: kfc-cache
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\SimpleCache\CacheInterface.KeysForCache:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "KeysForCache"

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,0 +1,6 @@
+---
+Name: kfc-extensions
+---
+SilverStripe\ORM\DataObject:
+  extensions:
+    CacheKeyExtension: Terraformers\KeysForCache\Extensions\CacheKeyExtension

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -2,8 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
-use SilverStripe\Dev\Debug;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
@@ -186,5 +187,12 @@ class CaresTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($newKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -2,7 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationCaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationCaredHasManyModel;
@@ -195,5 +197,12 @@ class DotNotationCaresTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($originalKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -2,7 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationTouchedBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationTouchedHasManyModel;
@@ -185,5 +187,12 @@ class DotNotationTouchesTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($newKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -2,7 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
@@ -136,5 +138,12 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($originalKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -2,7 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\TouchedBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\TouchedHasManyModel;
@@ -134,5 +136,12 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($originalKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/GlobalCaresTest.php
+++ b/tests/Scenarios/GlobalCaresTest.php
@@ -2,8 +2,10 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SiteConfig\SiteConfig;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\GlobalCaresPage;
 
@@ -38,5 +40,12 @@ class GlobalCaresTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($originalKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -2,7 +2,9 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\TouchedBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\TouchedHasManyModel;
@@ -186,5 +188,12 @@ class TouchesTest extends SapphireTest
         $this->assertNotNull($newKey);
         $this->assertNotEmpty($originalKey);
         $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    protected function tearDown(): void
+    {
+        Injector::inst()->get(Graph::CACHE_KEY)->clear();
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Fixes #14 
Closes #14

Using `feature/many-many-support` as the base so that I could test with "full support" added. Plus there were to method name changes on that branch.

## Manual test

I made a quick test that ran each `build` method 100 times, and then output the average time per iteration in milliseconds. I set this up on a recent project that has a reasonably small configuration layer (8 blocks, 2 pages, Site Config, etc).

I was surprised by how quick the build process was (on average) even when uncached, but it's worth mentioning that it will (of course) get worse with scale.

### Result

**Uncached - milliseconds per build iteration:** 22.61
**Cached - milliseconds per build iteration:** 0.63

### Test that I ran

```php
public function testPerformance(): void
{
    // Instantiate Graph. This should trigger a build
    $graph = Graph::singleton();

    // Use ReflectionClass to access private methods
    $reflectionClass = new ReflectionClass(Graph::class);
    $build = $reflectionClass->getMethod('buildEdges');
    $build->setAccessible(true);
    $create = $reflectionClass->getMethod('buildGlobalCares');
    $create->setAccessible(true);

    // Start the test
    $start = microtime(true);

    $testCount = 100;

    // Run our builds
    for ($i = 0; $i < $testCount; $i += 1) {
        $build->invoke($graph);
        $create->invoke($graph);
    }

    $end = microtime(true);
    $milliseconds = ($end - $start) / $testCount * 1000;
    // Average time per build
    Debug::dump(round($milliseconds, 2));
}
```

## Test coverage

- [x] Test cache is available after build
- [x] Test `Graph` properties are set correctly from cache on build
- [ ] Test `Graph` properties are set correctly from cache on secondary request