### PR TITLE
Remove spaces from the cache key

### DIFF
--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -109,6 +109,6 @@ class CacheKey extends DataObject
 
         $dataObject->invokeWithExtensions('updateGenerateKeyHash', $uniqueKey);
 
-        return implode('-', [$uniqueKey, microtime()]);
+        return implode('-', [$uniqueKey, microtime(true)]);
     }
 }


### PR DESCRIPTION
The space in the key is generated by `microtime($as_float)`. By default the `$as_float` parameter is false if we didn't set it, so the function returns the string with the structure: **microsec sec**. It has a space between the microsec sec. 
Simply set the `$as_float` parameter to be true, it will return a float representing the current time in seconds without space. This should fix https://github.com/silverstripe-terraformers/keys-for-cache/issues/21