### PR TITLE
Remove duplicate invoking createEdges in processChange

### DIFF
--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -28,8 +28,7 @@ abstract class CacheProcessingService
             return;
         }
 
-        $this->updateInstance($instance);
-        $edgesToUpdate = $this->createEdges($instance);
+        $edgesToUpdate = $this->updateInstance($instance);
 
         while (count($edgesToUpdate) > 0) {
             /** @var EdgeUpdateDto $current */


### PR DESCRIPTION
This should fix https://github.com/silverstripe-terraformers/keys-for-cache/issues/30

Remove the duplicate invoking `createEdges`, as the same work is done by the `updateInstance`.