### PR TITLE
Prevent classes in ignoreList from being used to build Edges

### DIFF
--- a/tests/RelationshipGraph/GraphTest.php
+++ b/tests/RelationshipGraph/GraphTest.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SiteConfig\SiteConfig;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Edge;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\RelationshipGraph\Node;
@@ -261,6 +262,21 @@ class GraphTest extends SapphireTest
         // There should now also be cache values
         $this->assertTrue($cache->has(Graph::CACHE_KEY_EDGES));
         $this->assertTrue($cache->has(Graph::CACHE_KEY_GLOBAL_CARES));
+    }
+
+    public function testGetValidClasses(): void
+    {
+        $graph = Graph::singleton();
+        $reflectionClass = new ReflectionClass(Graph::class);
+        $getValidClasses = $reflectionClass->getMethod('getValidClasses');
+        $getValidClasses->setAccessible(true);
+
+        $validClasses = $getValidClasses->invoke($graph);
+        $ignoreList = CacheKey::config()->get('ignorelist');
+        $intersect = array_intersect($validClasses, $ignoreList);
+
+        // validClasses shouldn't contain any value from ignore list
+        $this->assertCount(0, $intersect);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
We don't need to [build Edges](https://github.com/silverstripe-terraformers/keys-for-cache/blob/8a15b4c9edda7d7f1ef48269e0ffdf96e8df7159/src/RelationshipGraph/Graph.php#L186) for the classes in the ignoreList since we never mean to process their changes to update any cache keys. Picking them out from all DataObject classes to build Edges will bring a little performance enhancement to `buildEdges`.