### PR TITLE
Improve support for base and extended classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The overall aim of this module is twofold:
 2) Increase the performance of our applications by reducing the number of, and the complexity of the cache keys that we
    calculate at the time of an end user's request.
 
-* [API warning](#api-warning)
 * [Installation](#installation)
 * [Why cache keys are difficult](#why-cache-keys-are-difficult)
 * [How we aim to solve these difficulties](#how-we-aim-to-solve-these-difficulties)
@@ -30,11 +29,6 @@ The overall aim of this module is twofold:
 * [License](#license)
 * [Maintainers](#maintainers)
 * [Development and contribution](#development-and-contribution)
-
-## API warning:
-
-This module is still in the early days of its life and therefore could have its API changed/updated. That said, the
-public API is very small, so we will do our best to make no changes to it.
 
 ## Installation
 

--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -11,6 +11,7 @@ use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\View\ViewableData;
 use Terraformers\KeysForCache\Models\CacheKey;
 
 class Graph implements Flushable
@@ -44,10 +45,18 @@ class Graph implements Flushable
 
     public function getEdgesFrom(string $from): array
     {
+        $ancestry = ClassInfo::ancestry($from);
+        // Base classes that show up in every ancestry array
+        $disallowList = [
+            DataObject::class,
+            ViewableData::class,
+        ];
+
         return array_filter(
             $this->getEdges(),
-            static function (Edge $e) use ($from) {
-                return $e->getFromClassName() === $from;
+            static function (Edge $e) use ($ancestry, $disallowList) {
+                return in_array($e->getFromClassName(), $ancestry, true)
+                    && !in_array($e->getFromClassName(), $disallowList, true);
             }
         );
     }

--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Queries\SQLDelete;
 use Terraformers\KeysForCache\DataTransferObjects\EdgeUpdateDto;
 use Terraformers\KeysForCache\Models\CacheKey;
+use Terraformers\KeysForCache\RelationshipGraph\Edge;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 
 abstract class CacheProcessingService
@@ -127,7 +128,7 @@ abstract class CacheProcessingService
         }
 
         return array_map(
-            static function ($e) use ($instance) {
+            static function (Edge $e) use ($instance) {
                 return new EdgeUpdateDto($e, $instance);
             },
             $applicableEdges

--- a/tests/Mocks/Models/BaseCaredHasManyModel.php
+++ b/tests/Mocks/Models/BaseCaredHasManyModel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks\Models;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Tests\Mocks\Pages\ExtendedCaresPage;
+
+class BaseCaredHasManyModel extends DataObject
+{
+    private static array $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static array $has_one = [
+        'ExtendedCaresPage' => ExtendedCaresPage::class,
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+    ];
+
+    private static string $table_name = 'BaseCaredHasManyModel';
+
+    private static bool $has_cache_key = false;
+}

--- a/tests/Mocks/Models/BaseCaredHasOneModel.php
+++ b/tests/Mocks/Models/BaseCaredHasOneModel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks\Models;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Tests\Mocks\Pages\ExtendedCaresPage;
+
+class BaseCaredHasOneModel extends DataObject
+{
+    private static array $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static array $has_many = [
+        'ExtendedCaresPages' => ExtendedCaresPage::class,
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+    ];
+
+    private static string $table_name = 'BaseCaredHasOneModel';
+
+    private static bool $has_cache_key = false;
+}

--- a/tests/Mocks/Models/ExtendedCaredHasManyModel.php
+++ b/tests/Mocks/Models/ExtendedCaredHasManyModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks\Models;
+
+class ExtendedCaredHasManyModel extends BaseCaredHasManyModel
+{
+    private static array $db = [
+        'Description' => 'Varchar',
+    ];
+
+    private static string $table_name = 'ExtendedCaredHasManyModel';
+}

--- a/tests/Mocks/Models/ExtendedCaredHasOneModel.php
+++ b/tests/Mocks/Models/ExtendedCaredHasOneModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks\Models;
+
+class ExtendedCaredHasOneModel extends BaseCaredHasOneModel
+{
+    private static array $db = [
+        'Description' => 'Varchar',
+    ];
+
+    private static string $table_name = 'ExtendedCaredHasOneModel';
+}

--- a/tests/Mocks/Pages/ExtendedCaresPage.php
+++ b/tests/Mocks/Pages/ExtendedCaresPage.php
@@ -2,6 +2,25 @@
 
 namespace Terraformers\KeysForCache\Tests\Mocks\Pages;
 
+use Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasManyModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasOneModel;
+
 class ExtendedCaresPage extends CaresPage
 {
+    private static array $has_one = [
+        'BaseCaredHasOneModel' => BaseCaredHasOneModel::class,
+    ];
+
+    private static array $has_many = [
+        'BaseCaredHasManyModels' => BaseCaredHasManyModel::class,
+    ];
+
+    private static array $cares = [
+        'BaseCaredHasOneModel',
+        'BaseCaredHasManyModels',
+        'ExtendedCaredHasOneModel',
+        'ExtendedCaredHasManyModels',
+    ];
+
+    private static string $table_name = 'ExtendedCaresPage';
 }

--- a/tests/Mocks/Pages/ExtendedTouchedPage.php
+++ b/tests/Mocks/Pages/ExtendedTouchedPage.php
@@ -4,4 +4,5 @@ namespace Terraformers\KeysForCache\Tests\Mocks\Pages;
 
 class ExtendedTouchedPage extends TouchedPage
 {
+    private static string $table_name = 'ExtendedTouchedPage';
 }

--- a/tests/Mocks/Pages/ExtendedTouchesPage.php
+++ b/tests/Mocks/Pages/ExtendedTouchesPage.php
@@ -4,4 +4,5 @@ namespace Terraformers\KeysForCache\Tests\Mocks\Pages;
 
 class ExtendedTouchesPage extends TouchesPage
 {
+    private static string $table_name = 'ExtendedTouchesPage';
 }

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -6,11 +6,15 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
+use Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasManyModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasOneModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredManyManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredThroughModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasManyModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasOneModel;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\CaresPage;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\ExtendedCaresPage;
 use Terraformers\KeysForCache\Tests\Mocks\Relations\CaresPageCaredThroughModel;
@@ -24,6 +28,8 @@ class ExtendedCaresTest extends SapphireTest
      * @var array
      */
     protected static $extra_dataobjects = [
+        BaseCaredHasOneModel::class,
+        BaseCaredHasManyModel::class,
         CaresPage::class,
         CaresPageCaredThroughModel::class,
         CaredBelongsToModel::class,
@@ -32,6 +38,8 @@ class ExtendedCaresTest extends SapphireTest
         CaredManyManyModel::class,
         CaredThroughModel::class,
         ExtendedCaresPage::class,
+        ExtendedCaredHasOneModel::class,
+        ExtendedCaredHasManyModel::class,
     ];
 
     public function testCaresPureHasOne(): void
@@ -118,9 +126,6 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertNotEquals($originalKey, $newKey);
     }
 
-    /**
-     * This test is currently failing, and is a scenario we expect to support
-     */
     public function testCaresHasMany(): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -128,6 +133,114 @@ class ExtendedCaresTest extends SapphireTest
 
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(CaredHasManyModel::class, 'model1');
+
+        $originalKey = $page->getCacheKey();
+
+        $this->assertNotNull($originalKey);
+        $this->assertNotEmpty($originalKey);
+
+        $model->forceChange();
+        $model->write();
+
+        $newKey = $page->getCacheKey();
+
+        $this->assertNotNull($newKey);
+        $this->assertNotEmpty($originalKey);
+        $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    /**
+     * Testing that Base relationships work when the explicit class is used in the relationship
+     */
+    public function testBaseCaredHasOne(): void
+    {
+        // Updates are processed as part of scaffold, so we need to flush before we kick off
+        ProcessedUpdatesService::singleton()->flush();
+
+        $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
+        $model = $this->objFromFixture(BaseCaredHasOneModel::class, 'model1');
+
+        $originalKey = $page->getCacheKey();
+
+        $this->assertNotNull($originalKey);
+        $this->assertNotEmpty($originalKey);
+
+        $model->forceChange();
+        $model->write();
+
+        $newKey = $page->getCacheKey();
+
+        $this->assertNotNull($newKey);
+        $this->assertNotEmpty($originalKey);
+        $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    /**
+     * Testing that Base relationships work when the explicit class is used in the relationship
+     */
+    public function testBaseCaredHasMany(): void
+    {
+        // Updates are processed as part of scaffold, so we need to flush before we kick off
+        ProcessedUpdatesService::singleton()->flush();
+
+        $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
+        $model = $this->objFromFixture(BaseCaredHasManyModel::class, 'model1');
+
+        $originalKey = $page->getCacheKey();
+
+        $this->assertNotNull($originalKey);
+        $this->assertNotEmpty($originalKey);
+
+        $model->forceChange();
+        $model->write();
+
+        $newKey = $page->getCacheKey();
+
+        $this->assertNotNull($newKey);
+        $this->assertNotEmpty($originalKey);
+        $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    /**
+     * Now testing that a relationship to a Base class still works when the related object is an extended class
+     */
+    public function testExtendedCaredHasOne(): void
+    {
+        // Updates are processed as part of scaffold, so we need to flush before we kick off
+        ProcessedUpdatesService::singleton()->flush();
+
+        $page = $this->objFromFixture(ExtendedCaresPage::class, 'page3');
+        // This model is defined on an ExtendedCaresPage relationship that is for BaseCaredHasOneModel. This is a valid
+        // class extension that should also trigger an update
+        $model = $this->objFromFixture(ExtendedCaredHasOneModel::class, 'model1');
+
+        $originalKey = $page->getCacheKey();
+
+        $this->assertNotNull($originalKey);
+        $this->assertNotEmpty($originalKey);
+
+        $model->forceChange();
+        $model->write();
+
+        $newKey = $page->getCacheKey();
+
+        $this->assertNotNull($newKey);
+        $this->assertNotEmpty($originalKey);
+        $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    /**
+     * Now testing that a relationship to a Base class still works when the related object is an extended class
+     */
+    public function testExtendedCaredHasMany(): void
+    {
+        // Updates are processed as part of scaffold, so we need to flush before we kick off
+        ProcessedUpdatesService::singleton()->flush();
+
+        $page = $this->objFromFixture(ExtendedCaresPage::class, 'page3');
+        // This model is defined on an ExtendedCaresPage relationship that is for BaseCaredHasManyModel. This is a valid
+        // class extension that should also trigger an update
+        $model = $this->objFromFixture(ExtendedCaredHasManyModel::class, 'model1');
 
         $originalKey = $page->getCacheKey();
 

--- a/tests/Scenarios/ExtendedCaresTest.yml
+++ b/tests/Scenarios/ExtendedCaresTest.yml
@@ -10,6 +10,22 @@ Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel:
   model1:
     Title: Has Many Model 1
 
+Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasManyModel:
+  model1:
+    Title: Base Has Many Model 1
+
+Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasOneModel:
+  model1:
+    Title: Base Has One Model 1
+
+Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasManyModel:
+  model1:
+    Title: Extended Has Many Model 1
+
+Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasOneModel:
+  model1:
+    Title: Extended Has One Model 1
+
 Terraformers\KeysForCache\Tests\Mocks\Pages\ExtendedCaresPage:
   page1:
     Title: Page 1
@@ -17,3 +33,13 @@ Terraformers\KeysForCache\Tests\Mocks\Pages\ExtendedCaresPage:
     CaredHasOneModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel.model1
     CaredHasManyModels:
       - =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel.model1
+  page2:
+    Title: Page 2
+    BaseCaredHasOneModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasOneModel.model1
+    BaseCaredHasManyModels:
+      - =>Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasManyModel.model1
+  page3:
+    Title: Page 3
+    BaseCaredHasOneModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasOneModel.model1
+    BaseCaredHasManyModels:
+      - =>Terraformers\KeysForCache\Tests\Mocks\Models\ExtendedCaredHasManyModel.model1


### PR DESCRIPTION
Closes #35 

Details on the bug can be found above.

The goal is for us to find any `Edge` for the `instance` `ClassName` or any ancestor that the `instance` might have.

Regarding the `$disallowList` in `getEdgesFrom()`. Technically you can have a relationship to `DataObject` if you're using a polymorphic relationship. We haven't explicitly added support for polymorphic relationships though, so I opted to leave this our for now. I'll raise an improvement story for later.