### PR TITLE
Update Github Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.9
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,5 @@ jobs:
           phplinting: true
         - php: 7.4
           phpunit: true
-        - php: 8
+        - php: 8.0
           phpunit: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,3 +7,13 @@ on:
 jobs:
   ci:
     uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.14
+    with:
+      default_jobs:
+        - php: 7.4
+          phpcoverage: true
+        - php: 7.4
+          phplinting: true
+        - php: 7.4
+          phpunit: true
+        - php: 8
+          phpunit: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.14
     with:
-      default_jobs:
+      default_jobs: |
         - php: 7.4
           phpcoverage: true
         - php: 7.4


### PR DESCRIPTION
Some security updates are available in the latest bugfix version/s of Silverstripe Github Actions CI