### PR TITLE
Use PublishSingle (by default) when publishing CacheKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ See: [Fluent support](docs/en/fluent.md)
 This will increase the queries to the database when `DataObjects` are updated. We are still pretty early into our
 performance tests, but so far it has not created an unreasonable amount of additional load time to author actions.
 
+**That said:**
+
+* You should still be aware of what `cares` and `touches` configuration you enabled.
+* If you start to notice performance issues with (say) Publishing a page, then you might need to reconsider the scope
+  of relationships that you `cares` or `touches` as part of your Page and related DataObjects (EG: Blocks).
+
 ### Queued jobs
 
 If you want to prevent content authors from getting slightly slower responses when editing in the CMS, you can queue a

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -148,7 +148,11 @@ class CacheKeyExtension extends DataExtension
         // If the owner is not Versioned (essentially meaning that it is *always* published), or if the owner is
         // currently published, then we want to make sure we publish our CacheKey as well
         if (!$this->owner->hasExtension(Versioned::class) || $this->owner->isPublished()) {
-            $cacheKey->publishRecursive();
+            if (CacheKey::config()->get('publish_recursive')) {
+                $cacheKey->publishRecursive();
+            } else {
+                $cacheKey->publishSingle();
+            }
         }
 
         return $cacheKey->KeyHash;

--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -32,6 +32,8 @@ class CacheKey extends DataObject
         Versioned::class,
     ];
 
+    private static bool $publish_recursive = false;
+
     /**
      * Update the CacheKey if it is invalidated,
      * Create a CacheKey if it is empty

--- a/tests/Models/CacheKeyTest.php
+++ b/tests/Models/CacheKeyTest.php
@@ -200,4 +200,9 @@ class CacheKeyTest extends SapphireTest
         $this->assertNotNull($key);
         $this->assertNotEquals($keyHash, $key->KeyHash);
     }
+
+    public function testCacheKeyPublishRecursiveDefault(): void
+    {
+        $this->assertFalse(CacheKey::config()->get('publish_recursive'));
+    }
 }


### PR DESCRIPTION
## Performance

Just very light performance testing, but I created a Page with 13 different types of blocks (carousels, text, icons, etc), all with many different related records. I edited each block and then published the Page.

* Using `CacheKey::publishRecursive()` I had an average publish time of 15.85 seconds.
* Using `CacheKey::publishSingle()` I had an average publish time of 13.14 seconds.

## Considerations

I do not believe that we currently have a use case for the `CacheKey` model having `owns` relationships that we need to publish alongside the `CacheKey`. Switching to `publishSingle()` seems like a quick win to achieve a small (but noticeable) performance improvement.

## New config added to allow publish recursive

`publish_recursive` can now be set on `CacheKey` to re-enable the original behaviour.