### PR TITLE
Collate build errors before throwing exception

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -69,6 +69,8 @@
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
         <!-- We don't control the order of declaration based on access level -->
         <exclude name="SlevomatCodingStandard.Classes.ClassStructure"/>
+        <!-- Allow our exceptions to have the word "Exception" in them -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
         <!-- Allow short ternary operator -->
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>
         <!-- You are not making me go \PHP_EOL -->

--- a/src/RelationshipGraph/GraphBuildException.php
+++ b/src/RelationshipGraph/GraphBuildException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Terraformers\KeysForCache\RelationshipGraph;
+
+use Exception;
+use Throwable;
+
+class GraphBuildException extends Exception
+{
+    public function __construct(array $errors, int $code = 0, Throwable $previous = null)
+    {
+        $message = sprintf("\r\n%s", implode("\r\n", $errors));
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/RelationshipGraph/GraphBuildException.php
+++ b/src/RelationshipGraph/GraphBuildException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class GraphBuildException extends Exception
 {
-    public function __construct(array $errors, int $code = 0, Throwable $previous = null)
+    public function __construct(array $errors, int $code = 0, ?Throwable $previous = null)
     {
         $message = sprintf("\r\n%s", implode("\r\n", $errors));
 

--- a/tests/RelationshipGraph/GraphBuildExceptionTest.php
+++ b/tests/RelationshipGraph/GraphBuildExceptionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\RelationshipGraph;
+
+use SilverStripe\Dev\SapphireTest;
+use Terraformers\KeysForCache\RelationshipGraph\GraphBuildException;
+
+class GraphBuildExceptionTest extends SapphireTest
+{
+    public function testErrorsConvertedToMessage(): void
+    {
+        $errors = [
+            'Error 1',
+            'Error 2',
+            'Error 3',
+        ];
+
+        $this->expectExceptionMessage(sprintf("\r\n%s", implode("\r\n", $errors)));
+
+        throw new GraphBuildException($errors);
+    }
+}


### PR DESCRIPTION
Currently we throw an `Exception` as soon as we hit the first relationship error. This means that devs often run `dev/build`, fix one issue, run `dev/build` again, fix one more issue, and on and on until all errors are fixed.

Example new Exception message:

```bash
ERROR [Emergency]: Uncaught Terraformers\KeysForCache\RelationshipGraph\GraphBuildException:
No valid has_many or belongs_to found between Sheadawson\Linkable\Models\Link and App\Models\IconBlockItem for has_one relationship IconBlockLink
No valid has_many or belongs_to found between Sheadawson\Linkable\Models\Link and App\Models\ImageCarouselBlockItem for has_one relationship Link
No valid has_many or belongs_to found between Sheadawson\Linkable\Models\Link and App\Models\LinkBlockItem for has_one relationship LinkBlockItem
IN GET dev/build
Line 394 in /var/www/mysite/www/vendor/silverstripe-terraformers/keys-for-cache/src/RelationshipGraph/Graph.php
```

The goal being to give developers as many errors as possible in one go, so that they can attempt to fix them all before running the next `dev/build`.

Closes #33