### PR TITLE
Add Extension for GridFieldOrderableRows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ The overall aim of this module is twofold:
     * [Touches](#touches)
     * [Global cares](#global-cares)
     * [Usage and Examples](docs/en/examples.md)
-* [Fluent support](#fluent-support)
 * [Performance impact/considerations](#performance-impactconsiderations)
     * [Queued jobs](#queued-jobs)
+* [Fluent support](#fluent-support)
+* [GridField Orderable support](#gridfield-orderable-support)
 * [License](#license)
 * [Maintainers](#maintainers)
 * [Development and contribution](#development-and-contribution)
@@ -263,10 +264,6 @@ updated. This is a mechanism of global updates to ensure we don't run into perfo
 
 See: [Usage and Examples](docs/en/examples.md)
 
-## Fluent support
-
-See: [Fluent support](docs/en/fluent.md)
-
 ## Performance impact/considerations
 
 This will increase the queries to the database when `DataObjects` are updated. We are still pretty early into our
@@ -283,6 +280,14 @@ performance tests, but so far it has not created an unreasonable amount of addit
 If you want to prevent content authors from getting slightly slower responses when editing in the CMS, you can queue a
 job to generate the cache updates by injecting over `CacheKeyExtension` and updating `triggerEvent` to create a job then
 call `CacheRelationService::singleton()->processChange($this->DataObject)` in the job.
+
+## Fluent support
+
+See: [Fluent support](docs/en/fluent.md)
+
+## GridField Orderable support
+
+See: [GridField Orderable support](docs/en/gridfield-orderable.md)
 
 ## License
 

--- a/docs/en/gridfield-orderable.md
+++ b/docs/en/gridfield-orderable.md
@@ -1,0 +1,39 @@
+# GridField Orderable support
+
+* [Considerations & Warnings](#considerations--warnings)
+* [Applying the Extension](#applying-the-extension)
+
+## Considerations & Warnings
+
+If you are using `symbiote/silverstripe-gridfieldextensions` and the `GridFieldOrderableRows` component:
+
+* `GridFieldOrderableRows` will have out of the box support for KFC for `Versioned` DataObjects, as it already uses the
+  ORM and the `write()` method to save sort orders.
+* `GridFieldOrderableRows` unfortunately does **not** use the `write()` method for non `Versioned` DataObjects, it
+  instead performs raw SQL queries, which completely bypasses the triggers we have attached to `write()`.
+
+There is an open ticket on the GridFieldExtensions module to try and get GridFieldOrderableRows to use the ORM for both
+Versioned and non-Versioned DataObjects:
+https://github.com/symbiote/silverstripe-gridfieldextensions/issues/335
+
+In the meantime though, we have provided an Extension that adds support for clearing of CacheKeys on non `Versioned`
+DataObjects when you are using the GridFieldOrderableRows component.
+
+* `GridFieldOrderableRowsExtension`
+
+This Extension is *not* automatically applied, because I think you should seriously consider Versioning your DataObject.
+If you are adding this DataObject to (something like) an Element, which **is** Versioned, then (imo) it is best that all
+of the related DataObjects (like its "Items") are also `Versioned`. This gives a consistent author experience - where
+they can have draft/live versions of things.
+
+This Extension also doesn't have any test coverage (because of everything we mentioned above). It has only gone through
+manual testing. Use at your own risk and be prepared to submit tickets if you find any issues or use cases that aren't
+supported.
+
+## Applying the Extension
+
+```yaml
+Symbiote\GridFieldExtensions\GridFieldOrderableRows:
+  extensions:
+    - Terraformers\KeysForCache\Extensions\GridFieldOrderableRowsExtension
+```

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -95,7 +95,7 @@ class CacheKeyExtension extends DataExtension
         $this->triggerEvent(true);
     }
 
-    protected function triggerEvent(bool $publishUpdates = false): void
+    public function triggerEvent(bool $publishUpdates = false): void
     {
         $ignoreList = Config::forClass(CacheKey::class)->get('ignorelist');
 

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -73,7 +73,7 @@ class CacheKeyExtension extends DataExtension
         // We will want to publish changes to the CacheKey onAfterWrite if the instance triggering this event is *not*
         // Versioned (the changes should be seen immediately even though the object wasn't Published)
         $publishUpdates = !$this->owner->hasExtension(Versioned::class);
-        $this->triggerEvent($publishUpdates);
+        $this->triggerCacheEvent($publishUpdates);
     }
 
     public function onAfterDelete(): void
@@ -81,21 +81,21 @@ class CacheKeyExtension extends DataExtension
         // We will want to publish changes to the CacheKey onAfterWrite if the instance triggering this event is *not*
         // Versioned (the changes should be seen immediately even though the object wasn't Published)
         $publishUpdates = !$this->owner->hasExtension(Versioned::class);
-        $this->triggerEvent($publishUpdates);
+        $this->triggerCacheEvent($publishUpdates);
         CacheKey::remove($this->owner);
     }
 
     public function onAfterPublish(): void
     {
-        $this->triggerEvent(true);
+        $this->triggerCacheEvent(true);
     }
 
     public function onAfterUnpublish(): void
     {
-        $this->triggerEvent(true);
+        $this->triggerCacheEvent(true);
     }
 
-    public function triggerEvent(bool $publishUpdates = false): void
+    public function triggerCacheEvent(bool $publishUpdates = false): void
     {
         $ignoreList = Config::forClass(CacheKey::class)->get('ignorelist');
 

--- a/src/Extensions/GridFieldOrderableRowsExtension.php
+++ b/src/Extensions/GridFieldOrderableRowsExtension.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Terraformers\KeysForCache\Extensions;
+
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataQueryManipulator;
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\ORM\ManyManyThroughQueryManipulator;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * You do not need this Extension for Versioned DataObject. They are supported out of the box because
+ * GridFieldOrderableRows already performs a write() through the ORM when sorting Versioned DataObjects.
+ *
+ * This Extension is *not* automatically applied because I think you should seriously consider Versioning your
+ * DataObject. If you are adding this DataObject to (something like) an Element, which *is* Versioned, then (imo) it is
+ * best that all of the related DataObjects (like its "Items") are also Versioned. This gives a consistent author
+ * experience - where they can have draft/live versions of things. You can then also rely on the existing support from
+ * GridFieldOrderableRows.
+ *
+ * There is an open ticket on the GridFieldExtensions module to try and get GridFieldOrderableRows to use the ORM for
+ * both Versioned and non-Versioned DataObjects:
+ * https://github.com/symbiote/silverstripe-gridfieldextensions/issues/335
+ *
+ * In the meantime though, this Extension provides you a way to support the clearing of CacheKeys on non-Versioned
+ * DataObjects when you are using the GridFieldOrderableRows component.
+ *
+ * This Extension also doesn't have any test coverage (because of everything we mentioned above). It has only gone
+ * through manual testing. Use at your own risk and be prepared to submit tickets if you find any issues or use cases
+ * that aren't supported.
+ */
+class GridFieldOrderableRowsExtension extends Extension
+{
+    /**
+     * @param SS_List $list The List of records being sorted
+     * @param array $values [listItemID => currentSortValue]
+     * @param array $sortedIDs [newSortValue => listItemID]
+     * @return void
+     */
+    public function onAfterReorderItems(SS_List $list, array $values, array $sortedIDs): void
+    {
+        // We only support this action for DataList and ArrayList (as we know they can hold DataObjects)
+        if (!$list instanceof DataList && !$list instanceof ArrayList) {
+            return;
+        }
+
+        $class = $list->dataClass();
+        $isVersioned = false;
+
+        // This is important for two reasons. The first is that we need to know whether we are sorting a Through
+        // class or the Relation class. The second is that we need to know if that DataObject is Versioned, if it is
+        // then the default GridFieldOrderableRows::reorderItems() will have triggered all the actions we need already
+        if ($list instanceof ManyManyThroughList) {
+            // We'll be updating the Through class, not the Relation class
+            $class = $this->getManyManyInspector($list)->getJoinClass();
+            $isVersioned = $class::create()->hasExtension(Versioned::class);
+        } elseif (!$this->isManyMany($list)) {
+            $isVersioned = $class::create()->hasExtension(Versioned::class);
+        }
+
+        // Check to see whether this List would already have been processed through the ORM, and therefor has already
+        // triggered the events that we need
+        if ($isVersioned) {
+            return;
+        }
+
+        // We can't do anything with the Ordered DataObject if it doesn't have our CacheKeyExtension applied
+        if (!Extensible::has_extension($class, CacheKeyExtension::class)) {
+            return;
+        }
+
+        // The problem is that $sortedIDs is a list of the _related_ item IDs, which causes trouble
+        // with ManyManyThrough, where we need the ID of the _join_ item in order to set the value.
+        $itemToSortReference = ($list instanceof ManyManyThroughList) ? 'getJoin' : 'Me';
+        $currentSortList = $list->map('ID', $itemToSortReference)->toArray();
+
+        // Our List has already been processed and saved at this point, so we cannot access anything like the changed()
+        // methods for our DataObjects
+        // We do, however, have the original and new sort values, so we can run a comparison on those
+        foreach ($sortedIDs as $sortValue => $listItemID) {
+            // It should exist, but if it doesn't we'll just ignore it
+            if (!array_key_exists($listItemID, $values)) {
+                continue;
+            }
+
+            // Check to see if the value is still the same as it was before. If it is, then we don't need to do anything
+            if ($values[$listItemID] === $sortValue) {
+                continue;
+            }
+
+            /** @var DataObject|CacheKeyExtension $record */
+            $record = $currentSortList[$listItemID];
+
+            // Sanity checks
+            if (!$record->isInDB()) {
+                continue;
+            }
+
+            // We know that we need to publish these events, as this is a non-Versioned DataObject
+            $record->triggerEvent(true);
+        }
+    }
+
+    /**
+     * This is a copy/paste of the method used in GridFieldOrderableRow. We need it here as we're performing the same
+     * check/s
+     *
+     * @param SS_List $list
+     * @return DataQueryManipulator|ManyManyThroughQueryManipulator|SS_List
+     */
+    protected function getManyManyInspector(SS_List $list)
+    {
+        $inspector = $list;
+
+        if (!$list instanceof ManyManyThroughList) {
+            return $inspector;
+        }
+
+        foreach ($list->dataQuery()->getDataQueryManipulators() as $manipulator) {
+            if (!$manipulator instanceof ManyManyThroughQueryManipulator) {
+                continue;
+            }
+
+            return $manipulator;
+        }
+
+        return $inspector;
+    }
+
+    protected function isManyMany(SS_List $list): bool
+    {
+        return $list instanceof ManyManyList || $list instanceof ManyManyThroughList;
+    }
+}

--- a/src/Extensions/GridFieldOrderableRowsExtension.php
+++ b/src/Extensions/GridFieldOrderableRowsExtension.php
@@ -77,7 +77,9 @@ class GridFieldOrderableRowsExtension extends Extension
 
         // The problem is that $sortedIDs is a list of the _related_ item IDs, which causes trouble
         // with ManyManyThrough, where we need the ID of the _join_ item in order to set the value.
-        $itemToSortReference = ($list instanceof ManyManyThroughList) ? 'getJoin' : 'Me';
+        $itemToSortReference = $list instanceof ManyManyThroughList
+            ? 'getJoin'
+            : 'Me';
         $currentSortList = $list->map('ID', $itemToSortReference)->toArray();
 
         // Our List has already been processed and saved at this point, so we cannot access anything like the changed()

--- a/src/Extensions/GridFieldOrderableRowsExtension.php
+++ b/src/Extensions/GridFieldOrderableRowsExtension.php
@@ -103,7 +103,7 @@ class GridFieldOrderableRowsExtension extends Extension
             }
 
             // We know that we need to publish these events, as this is a non-Versioned DataObject
-            $record->triggerEvent(true);
+            $record->triggerCacheEvent(true);
         }
     }
 


### PR DESCRIPTION
## Considerations

`Versioned` DataObjects are supported OotB as `GridFieldOrderableRows` already saves sort orders using the `ORM` (which means that all of our triggers are already actioned). The only DataObjects that are **not** supported OotB are non `Versioned` DataObjects, as `GridFieldOrderableRows` performs SQL Queries (outside of the ORM) to update their sort orders.

I've raised a question on the GridField Extensions module to ask if we could use the ORM to save sort orders, which would mean that everything would work OotB (without this Extension) as all of our triggers would be actioned.

As such, I really do consider this Extension to be a "workaround".

## Alternatives

I think that folks should be considering adding `Versioned` to their DataObjects. There are definitely times where you might not want them to be `Versioned`, but I think that for models that are being managed through a CMS interface, it often makes sense to provide your authors with a consistent draft/live feature for all records that they manage.

If you add `Versioned` to the model that you are sorting, then everything should just work without this workaround.

## Conclusion

Here is an Extension that will work in the meantime, but I have not invested heavily in it. It has been run through manual testing, but I haven't written test coverage for it.

Use at your own risk, and be prepared to raise tickets/PRs if it's not working for your use case.