### PR TITLE
DOCS: Update cache docs, github actions, global_cares

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
-name: Module CI
+name: CI
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@v0.1
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,12 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -1,11 +1,22 @@
 # Usage and Examples
 
+* [A bit about the `cached` wrapper](#a-bit-about-the-cached-wrapper)
 * [Thinking about what you want to cache](#thinking-about-what-you-want-to-cache)
     * [One key to rule them all](#one-key-to-rule-them-all)
     * [Recommended approach](#recommended-approach)
 * [Caching your Blocks/Elements](#caching-your-blockselements)
 * [Headers, Footers, and other "global" content areas](#headers-footers-and-other-global-content-areas)
 * [Full usage example](#full-usage-example)
+
+## A bit about the `cached` wrapper
+
+The `<% cached ... %>` supports an `if` condition (as of framework 4.7). This can be really useful to use when you have
+a `DataObject` or area where you sometimes need it to be uncached.
+
+EG: `<% cached $CacheKey if $MyCondition %>`
+
+You could even use: `<% cached $CacheKey if $CacheKey %>`, and then any time you don't want a particular `DataObject` to
+be cached, you could implement the `updateCacheKey(CacheKeyDto $keyDto)` method and set the key to `null`.
 
 ## Thinking about what you want to cache
 
@@ -51,7 +62,7 @@ Save in: `/themes/[name]/templates/DNADesign/Elemental/Models/ElementalArea.ss`:
 ```silverstripe
 <% if $ElementControllers %>
     <% loop $ElementControllers %>
-        <% cached $Me.CacheKey %>
+        <% cached $Me.CacheKey if $Me.CacheKey %>
             $Me
         <% end_cached %>
     <% end_loop %>
@@ -88,6 +99,8 @@ it.
     </div>
 <% end_cached %>
 ```
+
+And then the Blocks that you **don't** want to cache could simply not add the `cached` wrapper.
 
 ## Headers, Footers, and other "global" content areas
 

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -25,7 +25,7 @@ class CacheKeyExtension extends DataExtension
     private static array $has_many = [
         // Programmatically we know that we will only ever create one of these CacheKey records per unique DataObject,
         // however, there is no unique index on CacheKey, and Silverstripe requires that our polymorphic relationships
-        // be defined in this way (because a has_many will technically be possible, from a data integrety p.o.v.)
+        // be defined in this way (because a has_many will technically be possible, from a data integrity p.o.v.)
         'CacheKeys' => CacheKey::class . '.Record',
     ];
 


### PR DESCRIPTION
Fixes #38 

Also ended up needing to update our Github actions, and that introduced some new PostgreSQL stuff which meant I needed to update how we delete old cache keys (can't use `SQLDelete`).