### PR TITLE
Bugfix: Fix an issue where belongs_to would trigger recursion

### DIFF
--- a/tests/Mocks/Models/CaredHasOneNonVersionedModel.php
+++ b/tests/Mocks/Models/CaredHasOneNonVersionedModel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Terraformers\KeysForCache\Tests\Mocks\Models;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
+use Terraformers\KeysForCache\Tests\Mocks\Pages\CaresPage;
+
+/**
+ * This model is referenced by CaresPage as a has_one, meaning that this model has a has_many back to CaresPage
+ *
+ * @property string $Title
+ * @method HasManyList|CaresPage CaresPages()
+ * @mixin CacheKeyExtension
+ */
+class CaredHasOneNonVersionedModel extends DataObject implements TestOnly
+{
+    private static array $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static array $has_many = [
+        'CaresPages' => CaresPage::class,
+    ];
+
+    private static string $table_name = 'CaredHasOneNonVersionedModel';
+
+    private static bool $has_cache_key = false;
+}

--- a/tests/Mocks/Pages/CaresPage.php
+++ b/tests/Mocks/Pages/CaresPage.php
@@ -12,6 +12,7 @@ use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneNonVersionedModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredManyManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredThroughModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\PolymorphicCaredHasManyModel;
@@ -20,9 +21,11 @@ use Terraformers\KeysForCache\Tests\Mocks\Relations\CaresPageCaredThroughModel;
 /**
  * @property int $CaredBelongsToModelID
  * @property int $CaredHasOneModelID
+ * @property int $CaredHasOneNonVersionedModelID
  * @property int $PolymorphicHasOneID
  * @method CaredBelongsToModel CaredBelongsToModel()
  * @method CaredHasOneModel CaredHasOneModel()
+ * @method CaredHasOneNonVersionedModel CaredHasOneNonVersionedModel()
  * @method DataObject PolymorphicHasOne()
  * @method HasManyList|CaredHasManyModel[] CaredHasManyModels()
  * @method HasManyList|CaresPageCaredThroughModel[] CaresPageCaredThroughModels()
@@ -35,6 +38,7 @@ class CaresPage extends Page implements TestOnly
     private static array $has_one = [
         'CaredBelongsToModel' => CaredBelongsToModel::class,
         'CaredHasOneModel' => CaredHasOneModel::class,
+        'CaredHasOneNonVersionedModel' => CaredHasOneNonVersionedModel::class,
         'PolymorphicHasOne' => DataObject::class,
     ];
 
@@ -56,6 +60,7 @@ class CaresPage extends Page implements TestOnly
     private static array $cares = [
         'CaredBelongsToModel',
         'CaredHasOneModel',
+        'CaredHasOneNonVersionedModel',
         'CaredHasManyModels',
         'CaredManyManyModels',
         'CaredThroughModels',

--- a/tests/RelationshipGraph/GraphTest.php
+++ b/tests/RelationshipGraph/GraphTest.php
@@ -15,6 +15,7 @@ use Terraformers\KeysForCache\RelationshipGraph\Node;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneNonVersionedModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredManyManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\PolymorphicCaredHasManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\PolymorphicTouchedHasManyModel;
@@ -167,6 +168,7 @@ class GraphTest extends SapphireTest
         $expectPageTwoCares = [
             'CaredBelongsToModel' => CaredBelongsToModel::class,
             'CaredHasOneModel' => CaredHasOneModel::class,
+            'CaredHasOneNonVersionedModel' => CaredHasOneNonVersionedModel::class,
             'CaredHasManyModels' => CaredHasManyModel::class,
             'CaredManyManyModels' => CaredManyManyModel::class,
             'CaredThroughModels' => [

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -9,6 +9,7 @@ use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel;
+use Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneNonVersionedModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredManyManyModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\CaredThroughModel;
 use Terraformers\KeysForCache\Tests\Mocks\Models\PolymorphicCaredHasManyModel;
@@ -30,6 +31,7 @@ class CaresTest extends SapphireTest
         CaredBelongsToModel::class,
         CaredHasManyModel::class,
         CaredHasOneModel::class,
+        CaredHasOneNonVersionedModel::class,
         CaredManyManyModel::class,
         CaredThroughModel::class,
         PolymorphicCaredHasOneModel::class,
@@ -103,6 +105,34 @@ class CaresTest extends SapphireTest
         // Check that we're set up correctly
         $this->assertEquals(CaredHasOneModel::class, $model->ClassName);
         $this->assertEquals($page->CaredHasOneModelID, $model->ID);
+
+        $originalKey = $page->getCacheKey();
+
+        $this->assertNotNull($originalKey);
+        $this->assertNotEmpty($originalKey);
+
+        // Begin changes
+        $model->forceChange();
+        $model->write();
+
+        $newKey = $page->getCacheKey();
+
+        $this->assertNotNull($newKey);
+        $this->assertNotEmpty($newKey);
+        $this->assertNotEquals($originalKey, $newKey);
+    }
+
+    public function testCaresHasOneNonVersioned(): void
+    {
+        // Updates are processed as part of scaffold, so we need to flush before we kick off
+        ProcessedUpdatesService::singleton()->flush();
+
+        $page = $this->objFromFixture(CaresPage::class, 'page1');
+        $model = $this->objFromFixture(CaredHasOneNonVersionedModel::class, 'model1');
+
+        // Check that we're set up correctly
+        $this->assertEquals(CaredHasOneNonVersionedModel::class, $model->ClassName);
+        $this->assertEquals($page->CaredHasOneNonVersionedModelID, $model->ID);
 
         $originalKey = $page->getCacheKey();
 

--- a/tests/Scenarios/CaresTest.yml
+++ b/tests/Scenarios/CaresTest.yml
@@ -6,6 +6,10 @@ Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel:
   model1:
     Title: Has One Model 1
 
+Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneNonVersionedModel:
+  model1:
+    Title: Has One Non Versioned Model 1
+
 Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel:
   model1:
     Title: Has Many Model 1
@@ -31,6 +35,7 @@ Terraformers\KeysForCache\Tests\Mocks\Pages\CaresPage:
     Title: Page 1
     CaredBelongsToModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredBelongsToModel.model1
     CaredHasOneModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneModel.model1
+    CaredHasOneNonVersionedModel: =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasOneNonVersionedModel.model1
     CaredHasManyModels:
       - =>Terraformers\KeysForCache\Tests\Mocks\Models\CaredHasManyModel.model1
     CaredManyManyModels:

--- a/tests/Scenarios/GlobalCaresTest.php
+++ b/tests/Scenarios/GlobalCaresTest.php
@@ -23,12 +23,11 @@ class GlobalCaresTest extends SapphireTest
 
     public function testGlobalCares(): void
     {
+        $siteConfig = SiteConfig::current_site_config();
+        $page = $this->objFromFixture(GlobalCaresPage::class, 'page1');
 
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
-
-        $siteConfig = SiteConfig::current_site_config();
-        $page = $this->objFromFixture(GlobalCaresPage::class, 'page1');
 
         // Check we're set up correctly
         $originalKey = $page->getCacheKey();


### PR DESCRIPTION
* In our `updateEdge()` method, we have a check for `alreadyProcessed()` for any `has_one` relationships.
* In the `updateInstances()` method, we have a check for `alreadyProcessed()` for each record that is passed in (this covers the `has_many/many_many/etc`).
* But we were missing a check for `belongs_to`. This was/is causing a loop.

Solution:

* Move the `alreadyProcessed()` check into our `updateInstance()` method. This is the singular entry point for updating an instance, so it makes sense to just always check here.
* One exception is that I've also left this check in the `processChange()` method as well. This is because this method also handles clearing of global cares.

Side note:

* I would like to add more un Versioned tests, but I felt this was an important fix to prioritise first.