### PR TITLE
Handle cases where relationship is UnsavedRelationList

### DIFF
--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\DataTransferObjects\EdgeUpdateDto;
 use Terraformers\KeysForCache\Models\CacheKey;
@@ -74,18 +75,13 @@ abstract class CacheProcessingService
         }
 
         if ($relationType === 'has_many' || $relationType === 'many_many' || $relationType === 'belongs_many_many') {
-            // It's possible that the relationship is an UnsavedRelationList, if so, we can't process this yet
-            if (!$instance->{$edge->getRelation()} instanceof DataList) {
-                return [];
-            }
-
             return $this->updateInstances($instance->{$edge->getRelation()}());
         }
 
         return [];
     }
 
-    private function updateInstances(DataList $instances): array
+    private function updateInstances(SS_List $instances): array
     {
         $results = [];
 
@@ -101,6 +97,10 @@ abstract class CacheProcessingService
 
     private function updateInstance(DataObject $instance): array
     {
+        if (!$instance->isInDB()) {
+            return [];
+        }
+
         if ($this->alreadyProcessed($instance->ClassName, $instance->ID)) {
             return [];
         }

--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -74,6 +74,11 @@ abstract class CacheProcessingService
         }
 
         if ($relationType === 'has_many' || $relationType === 'many_many' || $relationType === 'belongs_many_many') {
+            // It's possible that the relationship is an UnsavedRelationList, if so, we can't process this yet
+            if (!$instance->{$edge->getRelation()} instanceof DataList) {
+                return [];
+            }
+
             return $this->updateInstances($instance->{$edge->getRelation()}());
         }
 


### PR DESCRIPTION
When saving a DO, type error is thrown if one of the relationships is an `UnsavedRalationList` (expects `DataList`). This change introduces a check for instance of `DataList` before processing the relations.

