### PR TITLE
Resolve deprecation warning when calling static method on Extensible trait

### DIFF
--- a/src/Extensions/GridFieldOrderableRowsExtension.php
+++ b/src/Extensions/GridFieldOrderableRowsExtension.php
@@ -2,7 +2,6 @@
 
 namespace Terraformers\KeysForCache\Extensions;
 
-use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;

--- a/src/Extensions/GridFieldOrderableRowsExtension.php
+++ b/src/Extensions/GridFieldOrderableRowsExtension.php
@@ -75,7 +75,7 @@ class GridFieldOrderableRowsExtension extends Extension
         }
 
         // We can't do anything with the Ordered DataObject if it doesn't have our CacheKeyExtension applied
-        if (!Extensible::has_extension($class, CacheKeyExtension::class)) {
+        if (!DataObject::has_extension($class, CacheKeyExtension::class)) {
             return;
         }
 


### PR DESCRIPTION
On a non versioned dataobject, gridfieldorderablerowsextension throws deprecation warning when reordering objects:

[Deprecated] Calling static trait method SilverStripe\Core\Extensible::has_extension is deprecated, it should only be called on a class using the trait POST /admin/pages/edit/EditForm/34/field/ElementalArea/item/97/ItemEditForm/field/AccordionItems/reorder Line 78 in /var/www/mysite/www/vendor/silverstripe-terraformers/keys-for-cache/src/Extensions/GridFieldOrderableRowsExtension.php

Changing to DataObject (has trait Extensible, all gridfield objects should extend DO) fixes this. Not sure if this was introduced from php8 upgrade or the recent security patch