### PR TITLE
Bugfix: Set reading mode when reading/writing CacheKeys

### DIFF
--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -40,6 +40,7 @@ class CacheKeyExtension extends DataExtension
             return;
         }
 
+        // The configuration for this DataObject has specified that it does not use CacheKeys
         if (!$this->owner->config()->get('has_cache_key')) {
             return;
         }
@@ -127,10 +128,8 @@ class CacheKeyExtension extends DataExtension
             return null;
         }
 
-        // You have requested that this DataObject class does not use cache keys
-        $hasCacheKey = $this->owner->config()->get('has_cache_key');
-
-        if (!$hasCacheKey) {
+        // The configuration for this DataObject has specified that it does not use CacheKeys
+        if (!$this->owner->config()->get('has_cache_key')) {
             return null;
         }
 

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -81,6 +81,7 @@ class CacheKeyExtension extends DataExtension
         // We will want to publish changes to the CacheKey onAfterWrite if the instance triggering this event is *not*
         // Versioned (the changes should be seen immediately even though the object wasn't Published)
         $publishUpdates = !$this->owner->hasExtension(Versioned::class);
+        // Note: doArchive will call deleteFromStage() which will in turn trigger this extension hook
         $this->owner->triggerCacheEvent($publishUpdates);
         CacheKey::remove($this->owner);
     }
@@ -90,8 +91,17 @@ class CacheKeyExtension extends DataExtension
         $this->owner->triggerCacheEvent(true);
     }
 
+    public function onAfterPublishRecursive(): void
+    {
+        // This can sometimes be called in the same request as onAfterPublish(), but the duplication of effort is
+        // minimal since we keep track of which records have been processed
+        $this->owner->triggerCacheEvent(true);
+    }
+
     public function onAfterUnpublish(): void
     {
+        // Note: doArchive() will call doUnpublish(), so this extension hook is called when published records are
+        // archived
         $this->owner->triggerCacheEvent(true);
     }
 
@@ -117,25 +127,57 @@ class CacheKeyExtension extends DataExtension
             return null;
         }
 
+        // You have requested that this DataObject class does not use cache keys
         $hasCacheKey = $this->owner->config()->get('has_cache_key');
 
-        // You have requested that this DataObject class does not use cache keys
         if (!$hasCacheKey) {
             return null;
         }
 
-        // Find an existing CacheKey, or create a new one for this DataObject
+        // First we'll try to find this CacheKey in whatever your current Stage is (IE: We'll fetch LIVE records when
+        // you're in the LIVE reading_mode, and DRAFT records when you're in the DRAFT reading_mode)
+        $cacheKey = CacheKey::findInStage($this->owner);
+
+        // A key exists in your active Stage, so we can return it immediately
+        if ($cacheKey) {
+            return $cacheKey->KeyHash;
+        }
+
+        // We know that a CacheKey did not exist in your active Stage (that could have been DRAFT or LIVE). We'll now
+        // attempt to find an existing CacheKey (specifically in DRAFT), or we'll create a new one
+
+        // Given this context, our goal is now to make sure that we have a CacheKey for this record in the appropriate
+        // Stage. EG: If you are browsing this record in LIVE, then we'd expect to have a published CacheKey
         $cacheKey = CacheKey::findOrCreate($this->owner);
 
-        // In this context (that being, in a time where we are not actively generating Cache Keys, and are instead just
-        // trying to find them) we will not perform a write() when/if the StagingState indicates that we should not
+        // Safety first, but there shouldn't really have been a reason for this to be null
+        if (!$cacheKey) {
+            return null;
+        }
+
+        // In this context (that being, in a time when we are not actively generating Cache Keys, and are instead just
+        // trying to find them) we will not write() when/if the StagingState indicates that we should not
+        // One example is when browsing CMS Previews. We do not save CacheKeys in that context
         if (!StagingState::singleton()->canWrite()) {
             return $cacheKey->KeyHash;
         }
 
-        // Check that our CacheKey has been saved to the Database
+        // Make sure that our CacheKey is saved to the Database
         if (!$cacheKey->isInDB()) {
-            $cacheKey->write();
+            // We need to make sure that we are specifically writing this with reading mode set to DRAFT. If we write()
+            // while a user is browsing in a LIVE reading mode, then this CacheKey will be "live" immediately
+            // @see https://github.com/silverstripe/silverstripe-versioned/issues/382
+            Versioned::withVersionedMode(static function () use ($cacheKey): void {
+                Versioned::set_stage(Versioned::DRAFT);
+
+                $cacheKey->write();
+            });
+        }
+
+        // In this context we will not publish() when/if the StagingState indicates that we should not
+        // Generally, any time we're in a DRAFT reading_mode, we will not publish
+        if (!StagingState::singleton()->canPublish()) {
+            return $cacheKey->KeyHash;
         }
 
         // The Cache Key is already published, so there is nothing left for us to do except return the KeyHash
@@ -143,21 +185,12 @@ class CacheKeyExtension extends DataExtension
             return $cacheKey->KeyHash;
         }
 
-        // In this context we will not perform a publish() when/if the StagingState indicates that we should not
-        if (!StagingState::singleton()->canPublish()) {
-            return $cacheKey->KeyHash;
-        }
-
-        // If the owner is not Versioned (essentially meaning that it is *always* published), or if the owner is
-        // currently published, then we want to make sure we publish our CacheKey as well
-        if (!$this->owner->hasExtension(Versioned::class) || $this->owner->isPublished()) {
-            // Default behaviour is that publish_recursive is disabled. There is only value in using publishRecursive()
-            // if you decide that your CacheKey model needs to $own something
-            if (CacheKey::config()->get('publish_recursive')) {
-                $cacheKey->publishRecursive();
-            } else {
-                $cacheKey->publishSingle();
-            }
+        // Default behaviour is that publish_recursive is disabled. There is only value in using publishRecursive()
+        // if you decide that your CacheKey model needs to $own something
+        if (CacheKey::config()->get('publish_recursive')) {
+            $cacheKey->publishRecursive();
+        } else {
+            $cacheKey->publishSingle();
         }
 
         return $cacheKey->KeyHash;

--- a/src/Extensions/StagingExtension.php
+++ b/src/Extensions/StagingExtension.php
@@ -4,7 +4,6 @@ namespace Terraformers\KeysForCache\Extensions;
 
 use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Model\SiteTreeExtension;
-use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\State\StagingState;
 
 /**
@@ -15,15 +14,8 @@ class StagingExtension extends SiteTreeExtension
     public function contentcontrollerInit(ContentController $controller): void
     {
         // If we are currently browsing in a CMSPreview, then we do not want to write or publish any CacheKeys
-        if ($controller->getRequest()->getVar('CMSPreview')) {
+        if ($controller->getRequest()->getVar('CMSPreview')) { // phpcs:ignore
             StagingState::singleton()->disableWrite();
-            StagingState::singleton()->disablePublish();
-
-            return;
-        }
-
-        // If we are browsing in stage=Stage, then we do not want to publish any CacheKeys
-        if ($controller->getRequest()->getVar('stage') === Versioned::DRAFT) { // phpcs:ignore
             StagingState::singleton()->disablePublish();
         }
     }

--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -53,10 +53,8 @@ class CacheKey extends DataObject
 
     public static function findInStage(DataObject $dataObject): ?CacheKey
     {
-        // You have requested that this DataObject class does not use cache keys
-        $hasCacheKey = $dataObject->config()->get('has_cache_key');
-
-        if (!$hasCacheKey) {
+        // The configuration for this DataObject has specified that it does not use CacheKeys
+        if (!$dataObject->config()->get('has_cache_key')) {
             return null;
         }
 
@@ -74,10 +72,8 @@ class CacheKey extends DataObject
      */
     public static function findOrCreate(DataObject $dataObject): ?CacheKey
     {
-        // You have requested that this DataObject class does not use cache keys
-        $hasCacheKey = $dataObject->config()->get('has_cache_key');
-
-        if (!$hasCacheKey) {
+        // The configuration for this DataObject has specified that it does not use CacheKeys
+        if (!$dataObject->config()->get('has_cache_key')) {
             return null;
         }
 

--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -51,6 +51,22 @@ class CacheKey extends DataObject
         return $cacheKey;
     }
 
+    public static function findInStage(DataObject $dataObject): ?CacheKey
+    {
+        // You have requested that this DataObject class does not use cache keys
+        $hasCacheKey = $dataObject->config()->get('has_cache_key');
+
+        if (!$hasCacheKey) {
+            return null;
+        }
+
+        // This search will be performed in whatever your current Stage is
+        return static::get()->filter([
+            'RecordClass' => $dataObject->ClassName,
+            'RecordID' => $dataObject->ID,
+        ])->first();
+    }
+
     /**
      * @param DataObject|CacheKeyExtension $dataObject
      * @return CacheKey|null
@@ -58,6 +74,7 @@ class CacheKey extends DataObject
      */
     public static function findOrCreate(DataObject $dataObject): ?CacheKey
     {
+        // You have requested that this DataObject class does not use cache keys
         $hasCacheKey = $dataObject->config()->get('has_cache_key');
 
         if (!$hasCacheKey) {

--- a/src/State/StagingState.php
+++ b/src/State/StagingState.php
@@ -3,6 +3,7 @@
 namespace Terraformers\KeysForCache\State;
 
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Versioned\Versioned;
 
 class StagingState
 {
@@ -40,7 +41,11 @@ class StagingState
 
     public function canPublish(): bool
     {
-        return $this->publishEnabled;
+        if (!$this->publishEnabled) {
+            return false;
+        }
+
+        return Versioned::get_stage() === Versioned::LIVE;
     }
 
 }

--- a/tests/Extensions/CacheKeyExtensionTest.php
+++ b/tests/Extensions/CacheKeyExtensionTest.php
@@ -5,10 +5,10 @@ namespace Terraformers\KeysForCache\Tests\Extensions;
 use Page;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataList;
+use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\CachePage;
-use Terraformers\KeysForCache\Tests\Mocks\Pages\GlobalCaresPage;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\NoCachePage;
 
 class CacheKeyExtensionTest extends SapphireTest
@@ -24,90 +24,71 @@ class CacheKeyExtensionTest extends SapphireTest
         CachePage::class,
     ];
 
-    public function testWriteGeneratesCacheKey(): void
+    /**
+     * @dataProvider readingModes
+     */
+    public function testWriteGeneratesCacheKey(string $readingMode): void
     {
-        // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
-        $page = CachePage::create();
-        $page->write();
+        $page = Versioned::withVersionedMode(static function () use ($readingMode): CachePage {
+            // Testing within our requested reading mode
+            Versioned::set_stage($readingMode);
 
-        // Fetch all CacheKeys for this ClassName and ID
-        $keys = CacheKey::get()->filter([
-            'RecordClass' => $page->ClassName,
-            'RecordID' => $page->ID,
-        ]);
+            // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
+            $page = CachePage::create();
+            // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+            // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
+            $page->write();
 
-        // There should be exactly 1
-        $this->assertCount(1, $keys);
+            return $page;
+        });
+
+        Versioned::withVersionedMode(function () use ($page): void {
+            // Always fetch in DRAFT stage (because we expect this CacheKey to only be available in DRAFT)
+            Versioned::set_stage(Versioned::DRAFT);
+
+            // Re-fetch all CacheKeys for this ClassName and ID
+            $cacheKeys = CacheKey::get()->filter([
+                'RecordClass' => $page->ClassName,
+                'RecordID' => $page->ID,
+            ]);
+
+            // There should be exactly 1
+            $this->assertCount(1, $cacheKeys);
+
+            /** @var CacheKey $cacheKey */
+            $cacheKey = $cacheKeys->first();
+
+            // Performing write() on our Page should mean that the CacheKey is not published, regardless of what
+            // reading mode we were in
+            $this->assertFalse($cacheKey->isPublished());
+        });
     }
 
-    public function testWriteDoesNotGenerateCacheKey(): void
+    /**
+     * @dataProvider readingModes
+     */
+    public function testWriteDoesNotGenerateCacheKey(string $readingMode): void
     {
-        // Page config is $has_cache_key = false, so when we write this record it should not generate a CacheKey
-        $page = NoCachePage::create();
-        $page->write();
+        Versioned::withVersionedMode(function () use ($readingMode): void {
+            // Testing within our requested reading mode
+            Versioned::set_stage($readingMode);
 
-        // Fetch all CacheKeys for this ClassName and ID
-        $keys = CacheKey::get()->filter([
-            'RecordClass' => $page->ClassName,
-            'RecordID' => $page->ID,
-        ]);
+            // Page config is $has_cache_key = false, so when we write this record it should not generate a CacheKey
+            $page = NoCachePage::create();
+            $page->write();
 
-        // There shouldn't be any
-        $this->assertCount(0, $keys);
-    }
+            // We expect getCacheKey() to always return null
+            $this->assertNull($page->getCacheKey());
 
-    public function testPublishUpdatesCacheKey(): void
-    {
-        $parent = $this->objFromFixture(CachePage::class, 'page1');
-        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
+            // Re-fetch all CacheKeys for this ClassName and ID
+            $cacheKeys = CacheKey::get()->filter([
+                'RecordClass' => $page->ClassName,
+                'RecordID' => $page->ID,
+            ]);
 
-        $childKey = $child->getCacheKey();
-
-        $this->assertNotNull($childKey);
-        $this->assertNotEmpty($childKey);
-
-        $parent->forceChange();
-        $parent->publishRecursive();
-
-        $this->assertNotEquals($childKey, $child->getCacheKey());
-    }
-
-    public function testUnpublishUpdatesCacheKey(): void
-    {
-        $parent = $this->objFromFixture(CachePage::class, 'page1');
-        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
-
-        $parent->forceChange();
-        $parent->publishRecursive();
-
-        $childKey = $child->getCacheKey();
-
-        $this->assertNotNull($childKey);
-        $this->assertNotEmpty($childKey);
-
-        ProcessedUpdatesService::singleton()->flush();
-
-        $parent->doUnpublish();
-
-        $this->assertNotEquals($childKey, $child->getCacheKey());
-    }
-
-    public function testDeleteUpdatesCacheKey(): void
-    {
-        // Flush our update service before we begin to trigger changes
-        ProcessedUpdatesService::singleton()->flush();
-
-        $parent = $this->objFromFixture(CachePage::class, 'page1');
-        $child = $this->objFromFixture(GlobalCaresPage::class, 'page1');
-
-        $childKey = $child->getCacheKey();
-
-        $this->assertNotNull($childKey);
-        $this->assertNotEmpty($childKey);
-
-        $parent->doArchive();
-
-        $this->assertNotEquals($childKey, $child->getCacheKey());
+            // There shouldn't be any CacheKeys
+            $this->assertCount(0, $cacheKeys);
+        });
     }
 
     public function testGetCacheKey(): void
@@ -133,53 +114,10 @@ class CacheKeyExtensionTest extends SapphireTest
         $this->assertEquals($key->KeyHash, $pageKey);
     }
 
-    public function testGetCacheKeyRegenerated(): void
+    public function testGetCacheKeyRegeneratedDraftOnly(): void
     {
-        // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
-        $page = CachePage::create();
-        $page->write();
-
-        // Fetch all CacheKeys for this ClassName and ID
-        /** @var DataList|CacheKey[] $keys */
-        $keys = CacheKey::get()->filter([
-            'RecordClass' => $page->ClassName,
-            'RecordID' => $page->ID,
-        ]);
-
-        // Delete them, so we know we're at square one with no keys available in the DB
-        foreach ($keys as $key) {
-            $key->doArchive();
-        }
-
-        // Make sure we're set up correctly with no existing cache key
-        $keys = CacheKey::get()->filter([
-            'RecordClass' => $page->ClassName,
-            'RecordID' => $page->ID,
-        ]);
-
-        $this->assertCount(0, $keys);
-
-        // Requesting getCacheKey should regenerate the key
-        $pageKey = $page->getCacheKey();
-
-        /** @var CacheKey $key */
-        $key = CacheKey::get()->filter([
-            'RecordClass' => $page->ClassName,
-            'RecordID' => $page->ID,
-        ])->first();
-
-        $this->assertNotNull($key);
-
-        $this->assertNotNull($pageKey);
-        $this->assertNotEmpty($pageKey);
-
-        // And check that the key itself was not published (as our page wasn't)
-        $this->assertFalse($key->isPublished());
-    }
-
-    public function testGetCacheKeyRegeneratedAndPublished(): void
-    {
-        // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
+        // For this test we need a published Page with no CacheKey
+        /** @var CachePage $page */
         $page = CachePage::create();
         $page->write();
         $page->publishRecursive();
@@ -196,30 +134,273 @@ class CacheKeyExtensionTest extends SapphireTest
             $key->doArchive();
         }
 
-        // Make sure we're set up correctly with no existing cache key
+        // Now that we're set up for the test, we want to attempt to find the CacheKeyHash for this page while we're in
+        // a DRAFT reading mode
+        $keyHash = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with DRAFT reading mode
+            Versioned::set_stage(Versioned::DRAFT);
+
+            // Expected behaviour here is that we should have created a brand new CacheKey for this Page, but we won't
+            // publish it because we're not in a LIVE reading mode
+            return $page->getCacheKey();
+        });
+
+        $this->assertNotNull($keyHash);
+        $this->assertNotEmpty($keyHash);
+
+        // Re-fetch CacheKeys for this page
+        /** @var DataList|CacheKey[] $keys */
         $keys = CacheKey::get()->filter([
             'RecordClass' => $page->ClassName,
             'RecordID' => $page->ID,
         ]);
 
-        $this->assertCount(0, $keys);
-
-        // Requesting getCacheKey should regenerate the key
-        $pageKey = $page->getCacheKey();
+        // We expect there to only be one
+        $this->assertCount(1, $keys);
 
         /** @var CacheKey $key */
-        $key = CacheKey::get()->filter([
+        $key = $keys->first();
+
+        // We expect that the CacheKey was not published
+        $this->assertFalse($key->isPublished());
+    }
+
+    public function testGetCacheKeyRegeneratedAndPublished(): void
+    {
+        // For this test we need a published Page with no CacheKey
+        /** @var CachePage $page */
+        $page = CachePage::create();
+        $page->write();
+        $page->publishRecursive();
+
+        // Fetch all CacheKeys for this ClassName and ID
+        /** @var DataList|CacheKey[] $keys */
+        $keys = CacheKey::get()->filter([
             'RecordClass' => $page->ClassName,
             'RecordID' => $page->ID,
-        ])->first();
+        ]);
+
+        // Delete them, so we know we're at square one with no keys available in the DB
+        foreach ($keys as $key) {
+            $key->doArchive();
+        }
+
+        // Now that we're set up for the test, we want to attempt to find the CacheKeyHash for this page while we're in
+        // a LIVE reading mode
+        $keyHash = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with LIVE reading mode
+            Versioned::set_stage(Versioned::LIVE);
+
+            // Expected behaviour here is that we should have created a brand new CacheKey for this Page, and we should
+            // publish it because we're in a LIVE reading mode
+            return $page->getCacheKey();
+        });
+
+        $this->assertNotNull($keyHash);
+        $this->assertNotEmpty($keyHash);
+
+        // Re-fetch CacheKeys for this page
+        /** @var DataList|CacheKey[] $keys */
+        $keys = CacheKey::get()->filter([
+            'RecordClass' => $page->ClassName,
+            'RecordID' => $page->ID,
+        ]);
+
+        // We expect there to only be one
+        $this->assertCount(1, $keys);
+
+        /** @var CacheKey $key */
+        $key = $keys->first();
+
+        // We expect that one CacheKey to have been published
+        $this->assertTrue($key->isPublished());
+    }
+
+    public function testGetCacheKeyPublishedFromDraft(): void
+    {
+        // For this test we need a published Page with no CacheKey
+        /** @var CachePage $page */
+        $page = CachePage::create();
+        $page->write();
+        $page->publishRecursive();
+
+        // Fetch all CacheKeys for this ClassName and ID
+        /** @var DataList|CacheKey[] $keys */
+        $keys = CacheKey::get()->filter([
+            'RecordClass' => $page->ClassName,
+            'RecordID' => $page->ID,
+        ]);
+
+        // Make sure there is only one CacheKey
+        $this->assertCount(1, $keys);
+
+        /** @var CacheKey $key */
+        $key = $keys->first();
+        // Save away our KeyHash so that we can check it doesn't change
+        $keyHashOriginal = $key->KeyHash;
+
+        // Unpublish that one CacheKey
+        $key->doUnpublish();
+
+        // Re-fetch our key just to make sure that it is unpublished
+        $key = CacheKey::get()->byID($key->ID);
 
         $this->assertNotNull($key);
+        $this->assertFalse($key->isPublished());
 
-        $this->assertNotNull($pageKey);
-        $this->assertNotEmpty($pageKey);
+        // Now that we're set up for the test, we want to attempt to find the CacheKeyHash for this page while we're in
+        // a LIVE reading mode
+        $keyHashNew = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with LIVE reading mode
+            Versioned::set_stage(Versioned::LIVE);
 
-        // And check that the key itself was published (as our page was)
+            // Expected behaviour here is that we should find the original CacheKey (DRAFT only) and publish it
+            return $page->getCacheKey();
+        });
+
+        $this->assertNotNull($keyHashNew);
+        // This is the same CacheKey record as before, so this shouldn't have changed
+        $this->assertSame($keyHashOriginal, $keyHashNew);
+
+        // Re-fetch CacheKeys for this page
+        /** @var DataList|CacheKey[] $keys */
+        $keys = CacheKey::get()->filter([
+            'RecordClass' => $page->ClassName,
+            'RecordID' => $page->ID,
+        ]);
+
+        // We expect there to only be one
+        $this->assertCount(1, $keys);
+
+        /** @var CacheKey $key */
+        $key = $keys->first();
+
+        // We expect that one CacheKey to have been published
         $this->assertTrue($key->isPublished());
+    }
+
+    public function testCacheKeyStagesDiffer(): void
+    {
+        // Page config is $has_cache_key = true, so when we write this record it should generate a CacheKey
+        $page = CachePage::create();
+        $page->write();
+        $page->publishRecursive();
+
+        // Fetch all CacheKeys for this ClassName and ID to make sure we're set up correctly
+        /** @var DataList|CacheKey[] $keys */
+        $keys = CacheKey::get()->filter([
+            'RecordClass' => $page->ClassName,
+            'RecordID' => $page->ID,
+        ]);
+
+        // Make sure we have exactly one
+        $this->assertCount(1, $keys);
+
+        // Ok, so we've confirmed that we only have 1 CacheKey for our Page, now we want to fetch that CacheKey in
+        // specific Stages (DRAFT vs LIVE)
+
+        // Here's our CacheKey in DRAFT
+        $draftOriginal = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with DRAFT reading mode
+            Versioned::set_stage(Versioned::DRAFT);
+
+            $cacheKey = CacheKey::get()
+                ->filter([
+                    'RecordClass' => $page->ClassName,
+                    'RecordID' => $page->ID,
+                ])
+                ->first();
+
+            if (!$cacheKey) {
+                return null;
+            }
+
+            return $cacheKey->KeyHash;
+        });
+
+        // Here's our CacheKey in LIVE
+        $liveOriginal = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with DRAFT reading mode
+            Versioned::set_stage(Versioned::LIVE);
+
+            $cacheKey = CacheKey::get()
+                ->filter([
+                    'RecordClass' => $page->ClassName,
+                    'RecordID' => $page->ID,
+                ])
+                ->first();
+
+            if (!$cacheKey) {
+                return null;
+            }
+
+            return $cacheKey->KeyHash;
+        });
+
+        // Make sure they both existed
+        $this->assertNotNull($draftOriginal);
+        $this->assertNotNull($liveOriginal);
+        // These should be exactly the same, because we've recently published our Page
+        $this->assertEquals($draftOriginal, $liveOriginal);
+
+        // Need to flush our service so that keys are updated with future changes
+        ProcessedUpdatesService::singleton()->flush();
+
+        // Cool. So now let's make a DRAFT only change on our Page
+        $page->forceChange();
+        $page->write();
+
+        // Re-fetch our CacheKeys. This time we'll expect them to be different
+
+        // Here's our CacheKey in DRAFT
+        /** @var CacheKey $draftNew */
+        $draftNew = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with DRAFT reading mode
+            Versioned::set_stage(Versioned::DRAFT);
+
+            $cacheKey = CacheKey::get()
+                ->filter([
+                    'RecordClass' => $page->ClassName,
+                    'RecordID' => $page->ID,
+                ])
+                ->first();
+
+            if (!$cacheKey) {
+                return null;
+            }
+
+            return $cacheKey->KeyHash;
+        });
+
+        // Here's our CacheKey in LIVE
+        /** @var CacheKey $liveNew */
+        $liveNew = Versioned::withVersionedMode(static function () use ($page): ?string {
+            // Specifically fetching with DRAFT reading mode
+            Versioned::set_stage(Versioned::LIVE);
+
+            $cacheKey = CacheKey::get()
+                ->filter([
+                    'RecordClass' => $page->ClassName,
+                    'RecordID' => $page->ID,
+                ])
+                ->first();
+
+            if (!$cacheKey) {
+                return null;
+            }
+
+            return $cacheKey->KeyHash;
+        });
+
+        // Make sure they both existed
+        $this->assertNotNull($draftNew);
+        $this->assertNotNull($liveNew);
+        // We would expect the new DRAFT to differ from the original DRAFT
+        $this->assertNotEquals($draftOriginal, $draftNew);
+        // We would expect the new DRAFT and new LIVE to differ
+        $this->assertNotEquals($draftNew, $liveNew);
+        // We would expect the new LIVE to be the same as the original LIVE
+        $this->assertEquals($liveOriginal, $liveNew);
     }
 
     public function testGetCacheKeyNoDb(): void
@@ -289,6 +470,14 @@ class CacheKeyExtensionTest extends SapphireTest
                 'RecordID' => $page->ID,
             ])
         );
+    }
+
+    public function readingModes(): array
+    {
+        return [
+            [Versioned::DRAFT],
+            [Versioned::LIVE],
+        ];
     }
 
 }

--- a/tests/Mocks/Pages/CaresPage.php
+++ b/tests/Mocks/Pages/CaresPage.php
@@ -23,10 +23,12 @@ use Terraformers\KeysForCache\Tests\Mocks\Relations\CaresPageCaredThrough;
  * @property int $CaredBelongsToID
  * @property int $CaredHasOneID
  * @property int $CaredHasOneNonVersionedID
+ * @property int $CaredHasOneVersionedNonStagedID
  * @property int $PolymorphicHasOneID
  * @method CaredBelongsTo CaredBelongsTo()
  * @method CaredHasOne CaredHasOne()
  * @method CaredHasOneNonVersioned CaredHasOneNonVersioned()
+ * @method CaredHasOneVersionedNonStaged CaredHasOneVersionedNonStaged()
  * @method DataObject PolymorphicHasOne()
  * @method HasManyList|CaredHasMany[] CaredHasMany()
  * @method HasManyList|CaresPageCaredThrough[] CaresPageCaredThrough()

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -50,7 +50,7 @@ class CaresTest extends SapphireTest
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -66,13 +66,13 @@ class CaresTest extends SapphireTest
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -88,13 +88,13 @@ class CaresTest extends SapphireTest
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -110,7 +110,7 @@ class CaresTest extends SapphireTest
         $this->assertEquals(CaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->CaredHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -188,7 +188,7 @@ class CaresTest extends SapphireTest
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -204,13 +204,13 @@ class CaresTest extends SapphireTest
         $this->assertEquals(PolymorphicCaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -222,13 +222,13 @@ class CaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -240,13 +240,13 @@ class CaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testManyMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testManyMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -262,13 +262,13 @@ class CaresTest extends SapphireTest
         $this->assertCount(1, $page->CaredManyMany());
         $this->assertEquals($model->ID, $page->CaredManyMany()->first()->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testManyManyThrough(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testManyManyThrough(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -280,7 +280,7 @@ class CaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     protected function assertCacheKeyChanges(
@@ -288,38 +288,40 @@ class CaresTest extends SapphireTest
         DataObject $model,
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            // We perform our save method and read in the same reading mode
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                // We perform our save method and read in the same reading mode
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-            // Check that we're set up with an initial KeyHash
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                // Check that we're set up with an initial KeyHash
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates so that new changes generate new CacheKey hashes
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates so that new changes generate new CacheKey hashes
+                ProcessedUpdatesService::singleton()->flush();
 
-            $model->forceChange();
-            // @see readingModes() - write() or publishRecursive() depending on the test
-            $model->{$saveMethod}();
+                $model->forceChange();
+                // @see readingModes() - write() or publishRecursive() depending on the test
+                $model->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($newKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     public function readingModesWithSaveMethods(): array
@@ -327,16 +329,16 @@ class CaresTest extends SapphireTest
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
-            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
             // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
-            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
-            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
             // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
-            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];
     }
 

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -306,7 +306,9 @@ class CaresTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $model->forceChange();
-                // @see readingModes() - write() or publishRecursive() depending on the test
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $model->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -315,6 +317,7 @@ class CaresTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -330,13 +330,13 @@ class CaresTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -96,6 +96,9 @@ class DotNotationCaresTest extends SapphireTest
 
                 // Begin changes
                 $page->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $page->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -107,6 +110,7 @@ class DotNotationCaresTest extends SapphireTest
                 $this->assertNotEmpty($newKeyOne->KeyHash);
                 $this->assertNotEmpty($newKeyTwo->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
                     $this->assertNotEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);
@@ -192,6 +196,9 @@ class DotNotationCaresTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $modelOne->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $modelOne->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -200,6 +207,7 @@ class DotNotationCaresTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($originalKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {
@@ -213,6 +221,9 @@ class DotNotationCaresTest extends SapphireTest
                 $originalKey = $newKey;
 
                 $modelTwo->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $modelTwo->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -221,6 +232,7 @@ class DotNotationCaresTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($originalKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -236,13 +236,13 @@ class DotNotationCaresTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -4,6 +4,9 @@ namespace Terraformers\KeysForCache\Tests\Scenarios;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationCaredBelongsTo;
@@ -26,7 +29,10 @@ class DotNotationCaresTest extends SapphireTest
         DotNotationCaredHasOne::class,
     ];
 
-    public function testCaresPureHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -35,45 +41,24 @@ class DotNotationCaresTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationCaredBelongsTo::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationCaredBelongsTo::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationCaredBelongsTo::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationCaredBelongsTo::class, $modelTwo->ClassName);
         $this->assertEquals($page->CaredBelongsToFirstID, $modelOne->ID);
         $this->assertEquals($page->CaredBelongsToSecondID, $modelTwo->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $modelOne->forceChange();
-        $modelOne->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
-
-        // Flush updates again before we trigger another update
-        ProcessedUpdatesService::singleton()->flush();
-
-        // Update original key for the next change
-        $originalKey = $newKey;
-
-        // Begin changes
-        $modelTwo->forceChange();
-        $modelTwo->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testCaresBelongsTo(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -82,36 +67,61 @@ class DotNotationCaresTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationCaredBelongsTo::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationCaredBelongsTo::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationCaredBelongsTo::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationCaredBelongsTo::class, $modelTwo->ClassName);
         $this->assertEquals($page->CaredBelongsToFirstID, $modelOne->ID);
         $this->assertEquals($page->CaredBelongsToSecondID, $modelTwo->ID);
 
-        $originalKeyOne = $modelOne->getCacheKey();
-        $originalKeyTwo = $modelTwo->getCacheKey();
+        Versioned::withVersionedMode(
+            function () use ($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch): void {
+                Versioned::set_stage($readingMode);
 
-        $this->assertNotNull($originalKeyOne);
-        $this->assertNotNull($originalKeyTwo);
-        $this->assertNotEmpty($originalKeyOne);
-        $this->assertNotEmpty($originalKeyTwo);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKeyOne = CacheKey::findInStage($modelOne);
+                $originalKeyTwo = CacheKey::findInStage($modelTwo);
 
-        // Begin changes
-        $page->forceChange();
-        $page->write();
+                $this->assertNotNull($originalKeyOne);
+                $this->assertNotNull($originalKeyTwo);
+                $this->assertNotEmpty($originalKeyOne->KeyHash);
+                $this->assertNotEmpty($originalKeyTwo->KeyHash);
 
-        $newKeyOne = $modelOne->getCacheKey();
-        $newKeyTwo = $modelTwo->getCacheKey();
+                // Flush updates again before we trigger another update
+                ProcessedUpdatesService::singleton()->flush();
 
-        $this->assertNotNull($newKeyOne);
-        $this->assertNotNull($newKeyTwo);
-        $this->assertNotEmpty($newKeyOne);
-        $this->assertNotEmpty($newKeyTwo);
-        $this->assertNotEquals($originalKeyOne, $newKeyOne);
-        $this->assertNotEquals($originalKeyTwo, $newKeyTwo);
+                // Begin changes
+                $page->forceChange();
+                $page->{$saveMethod}();
+
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKeyOne = CacheKey::findInStage($modelOne);
+                $newKeyTwo = CacheKey::findInStage($modelTwo);
+
+                $this->assertNotNull($newKeyOne);
+                $this->assertNotNull($newKeyTwo);
+                $this->assertNotEmpty($newKeyOne->KeyHash);
+                $this->assertNotEmpty($newKeyTwo->KeyHash);
+
+                if ($expectMatch) {
+                    $this->assertEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
+                    $this->assertEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
+                    $this->assertNotEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);
+                }
+            }
+        );
     }
 
-    public function testCaresHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -120,45 +130,24 @@ class DotNotationCaresTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationCaredHasOne::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationCaredHasOne::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationCaredHasOne::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationCaredHasOne::class, $modelTwo->ClassName);
         $this->assertEquals($page->CaredHasOneFirstID, $modelOne->ID);
         $this->assertEquals($page->CaredHasOneSecondID, $modelTwo->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $modelOne->forceChange();
-        $modelOne->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
-
-        // Flush updates again before we trigger another update
-        ProcessedUpdatesService::singleton()->flush();
-
-        // Update original key for the next change
-        $originalKey = $newKey;
-
-        // Begin changes
-        $modelTwo->forceChange();
-        $modelTwo->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testCaresHasMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -167,40 +156,96 @@ class DotNotationCaresTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationCaredHasMany::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationCaredHasMany::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertCount(1, $page->CaredHasManyFirst());
         $this->assertEquals($page->CaredHasManyFirst()->first()->ID, $modelOne->ID);
         $this->assertCount(1, $page->CaredHasManySecond());
         $this->assertEquals($page->CaredHasManySecond()->first()->ID, $modelTwo->ID);
 
-        $originalKey = $page->getCacheKey();
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
+    }
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
+    protected function assertCacheKeyChanges(
+        DotNotationCaresPage $page,
+        DataObject $modelOne,
+        DataObject $modelTwo,
+        string $readingMode,
+        string $saveMethod,
+        bool $expectMatch
+    ): void {
+        Versioned::withVersionedMode(
+            function () use ($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch): void {
+                Versioned::set_stage($readingMode);
 
-        $modelOne->forceChange();
-        $modelOne->write();
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-        $newKey = $page->getCacheKey();
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+                // Flush updates again before we trigger another update
+                ProcessedUpdatesService::singleton()->flush();
 
-        // Flush updates again before we trigger another update
-        ProcessedUpdatesService::singleton()->flush();
+                $modelOne->forceChange();
+                $modelOne->{$saveMethod}();
 
-        // Update original key for the next change
-        $originalKey = $newKey;
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-        $modelTwo->forceChange();
-        $modelTwo->write();
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-        $newKey = $page->getCacheKey();
+                if ($expectMatch) {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+                // Flush updates again before we trigger another update
+                ProcessedUpdatesService::singleton()->flush();
+
+                // Update original key for the next change
+                $originalKey = $newKey;
+
+                $modelTwo->forceChange();
+                $modelTwo->{$saveMethod}();
+
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
+
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
+
+                if ($expectMatch) {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
+            }
+        );
+    }
+
+    public function readingModesWithSaveMethods(): array
+    {
+        return [
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // stage of our CacheKey
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+        ];
     }
 
     protected function tearDown(): void

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -241,13 +241,13 @@ class DotNotationTouchesTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -4,6 +4,9 @@ namespace Terraformers\KeysForCache\Tests\Scenarios;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\DotNotationTouchedBelongsTo;
@@ -30,7 +33,10 @@ class DotNotationTouchesTest extends SapphireTest
         DotNotationTouchesBelongsTo::class,
     ];
 
-    public function testTouchesHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -39,36 +45,24 @@ class DotNotationTouchesTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationTouchedHasOne::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationTouchedHasOne::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationTouchedHasOne::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationTouchedHasOne::class, $modelTwo->ClassName);
         $this->assertEquals($page->TouchedHasOneFirstID, $modelOne->ID);
         $this->assertEquals($page->TouchedHasOneSecondID, $modelTwo->ID);
 
-        $originalKeyOne = $modelOne->getCacheKey();
-        $originalKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($originalKeyOne);
-        $this->assertNotNull($originalKeyTwo);
-        $this->assertNotEmpty($originalKeyOne);
-        $this->assertNotEmpty($originalKeyTwo);
-
-        // Begin changes
-        $page->forceChange();
-        $page->write();
-
-        $newKeyOne = $modelOne->getCacheKey();
-        $newKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($newKeyOne);
-        $this->assertNotNull($newKeyTwo);
-        $this->assertNotEmpty($newKeyOne);
-        $this->assertNotEmpty($newKeyTwo);
-        $this->assertNotEquals($originalKeyOne, $newKeyOne);
-        $this->assertNotEquals($originalKeyTwo, $newKeyTwo);
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesPureHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesPureHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -77,39 +71,24 @@ class DotNotationTouchesTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationTouchedBelongsTo::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationTouchedBelongsTo::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationTouchedBelongsTo::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationTouchedBelongsTo::class, $modelTwo->ClassName);
         $this->assertEquals($page->TouchedBelongsToFirstID, $modelOne->ID);
         $this->assertEquals($page->TouchedBelongsToSecondID, $modelTwo->ID);
 
-        $originalKeyOne = $modelOne->getCacheKey();
-        $originalKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($originalKeyOne);
-        $this->assertNotNull($originalKeyTwo);
-        $this->assertNotEmpty($originalKeyOne);
-        $this->assertNotEmpty($originalKeyTwo);
-
-        // Begin changes
-        $page->forceChange();
-        $page->write();
-
-        $newKeyOne = $modelOne->getCacheKey();
-        $newKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($newKeyOne);
-        $this->assertNotNull($newKeyTwo);
-        $this->assertNotEmpty($newKeyOne);
-        $this->assertNotEmpty($newKeyTwo);
-        $this->assertNotEquals($originalKeyOne, $newKeyOne);
-        $this->assertNotEquals($originalKeyTwo, $newKeyTwo);
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
     }
 
     /**
-     * This test is currently failing, and is a scenario we expect to support
+     * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesHasMany(): void
+    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -118,35 +97,24 @@ class DotNotationTouchesTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationTouchedHasMany::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationTouchedHasMany::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertCount(1, $page->TouchedHasManyFirst());
         $this->assertEquals($page->TouchedHasManyFirst()->first()->ID, $modelOne->ID);
         $this->assertCount(1, $page->TouchedHasManySecond());
         $this->assertEquals($page->TouchedHasManySecond()->first()->ID, $modelTwo->ID);
 
-        $originalKeyOne = $modelOne->getCacheKey();
-        $originalKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($originalKeyOne);
-        $this->assertNotNull($originalKeyTwo);
-        $this->assertNotEmpty($originalKeyOne);
-        $this->assertNotEmpty($originalKeyTwo);
-
-        $page->forceChange();
-        $page->write();
-
-        $newKeyOne = $modelOne->getCacheKey();
-        $newKeyTwo = $modelTwo->getCacheKey();
-
-        $this->assertNotNull($newKeyOne);
-        $this->assertNotNull($newKeyTwo);
-        $this->assertNotEmpty($newKeyOne);
-        $this->assertNotEmpty($newKeyTwo);
-        $this->assertNotEquals($originalKeyOne, $newKeyOne);
-        $this->assertNotEquals($originalKeyTwo, $newKeyTwo);
+        $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesBelongsTo(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -155,42 +123,134 @@ class DotNotationTouchesTest extends SapphireTest
         $modelOne = $this->objFromFixture(DotNotationTouchesBelongsTo::class, 'model1');
         $modelTwo = $this->objFromFixture(DotNotationTouchesBelongsTo::class, 'model2');
 
+        // Make sure we publish our records
+        $page->publishRecursive();
+        $modelOne->publishRecursive();
+        $modelTwo->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(DotNotationTouchesBelongsTo::class, $modelOne->ClassName);
         $this->assertEquals(DotNotationTouchesBelongsTo::class, $modelTwo->ClassName);
         $this->assertEquals($page->TouchesBelongsToFirstID, $modelOne->ID);
         $this->assertEquals($page->TouchesBelongsToSecondID, $modelTwo->ID);
 
-        $originalKey = $page->getCacheKey();
+        Versioned::withVersionedMode(
+            function () use ($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch): void {
+                Versioned::set_stage($readingMode);
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-        // Begin changes
-        $modelOne->forceChange();
-        $modelOne->write();
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-        $newKey = $page->getCacheKey();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+                // Begin changes
+                $modelOne->forceChange();
+                $modelOne->{$saveMethod}();
 
-        // Flush updates again before we trigger the next change
-        ProcessedUpdatesService::singleton()->flush();
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-        // Begin changes
-        $modelTwo->forceChange();
-        $modelTwo->write();
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-        // Save our key again before we regenerate it
-        $originalKey = $newKey;
+                if ($expectMatch) {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
 
-        $newKey = $page->getCacheKey();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+                // Begin changes
+                $modelTwo->forceChange();
+                $modelTwo->{$saveMethod}();
+
+                // Save our key again before we regenerate it
+                $originalKey = $newKey;
+
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
+
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
+
+                if ($expectMatch) {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
+            }
+        );
+    }
+
+    protected function assertCacheKeyChanges(
+        DotNotationTouchesPage $page,
+        DataObject $modelOne,
+        DataObject $modelTwo,
+        string $readingMode,
+        string $saveMethod,
+        bool $expectMatch
+    ): void {
+        Versioned::withVersionedMode(
+            function () use ($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectMatch): void {
+                Versioned::set_stage($readingMode);
+
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKeyOne = CacheKey::findInStage($modelOne);
+                $originalKeyTwo = CacheKey::findInStage($modelTwo);
+
+                $this->assertNotNull($originalKeyOne);
+                $this->assertNotNull($originalKeyTwo);
+                $this->assertNotEmpty($originalKeyOne->KeyHash);
+                $this->assertNotEmpty($originalKeyTwo->KeyHash);
+
+                // Flush updates again before we trigger another update
+                ProcessedUpdatesService::singleton()->flush();
+
+                $page->forceChange();
+                $page->{$saveMethod}();
+
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKeyOne = CacheKey::findInStage($modelOne);
+                $newKeyTwo = CacheKey::findInStage($modelTwo);
+
+                $this->assertNotNull($newKeyOne);
+                $this->assertNotNull($newKeyTwo);
+                $this->assertNotEmpty($newKeyOne->KeyHash);
+                $this->assertNotEmpty($newKeyTwo->KeyHash);
+
+                if ($expectMatch) {
+                    $this->assertEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
+                    $this->assertEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);
+                } else {
+                    $this->assertNotEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
+                    $this->assertNotEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);
+                }
+            }
+        );
+    }
+
+    public function readingModesWithSaveMethods(): array
+    {
+        return [
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // stage of our CacheKey
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+        ];
     }
 
     protected function tearDown(): void

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -149,6 +149,9 @@ class DotNotationTouchesTest extends SapphireTest
 
                 // Begin changes
                 $modelOne->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $modelOne->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -157,6 +160,7 @@ class DotNotationTouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {
@@ -168,6 +172,9 @@ class DotNotationTouchesTest extends SapphireTest
 
                 // Begin changes
                 $modelTwo->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $modelTwo->{$saveMethod}();
 
                 // Save our key again before we regenerate it
@@ -179,6 +186,7 @@ class DotNotationTouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {
@@ -213,6 +221,9 @@ class DotNotationTouchesTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $page->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $page->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -224,6 +235,7 @@ class DotNotationTouchesTest extends SapphireTest
                 $this->assertNotEmpty($newKeyOne->KeyHash);
                 $this->assertNotEmpty($newKeyTwo->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKeyOne->KeyHash, $newKeyOne->KeyHash);
                     $this->assertNotEquals($originalKeyTwo->KeyHash, $newKeyTwo->KeyHash);

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -56,7 +56,7 @@ class ExtendedCaresTest extends SapphireTest
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -72,13 +72,13 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -94,13 +94,13 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -116,13 +116,13 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertEquals(CaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->CaredHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -138,14 +138,17 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertEquals(PolymorphicCaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testExtendedPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
-    {
+    public function testExtendedPolymorphicCaresHasOne(
+        string $readingMode,
+        string $saveMethod,
+        bool $expectKeyChange
+    ): void {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
 
@@ -160,13 +163,13 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertEquals(ExtendedPolymorphicCaredHasMany::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -178,13 +181,13 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -196,7 +199,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -205,7 +208,7 @@ class ExtendedCaresTest extends SapphireTest
     public function testExtendedPolymorphicCaresHasMany(
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -217,7 +220,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -225,7 +228,7 @@ class ExtendedCaresTest extends SapphireTest
      *
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testBaseCaredHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testBaseCaredHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -237,7 +240,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -245,7 +248,7 @@ class ExtendedCaresTest extends SapphireTest
      *
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testBaseCaredHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testBaseCaredHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -257,7 +260,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -265,7 +268,7 @@ class ExtendedCaresTest extends SapphireTest
      *
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testExtendedCaredHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testExtendedCaredHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -279,7 +282,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -287,7 +290,7 @@ class ExtendedCaresTest extends SapphireTest
      *
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testExtendedCaredHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testExtendedCaredHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -301,7 +304,7 @@ class ExtendedCaresTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     protected function assertCacheKeyChanges(
@@ -309,35 +312,37 @@ class ExtendedCaresTest extends SapphireTest
         DataObject $model,
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates again before we trigger the next change
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-            $model->forceChange();
-            $model->{$saveMethod}();
+                $model->forceChange();
+                $model->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     public function readingModesWithSaveMethods(): array
@@ -345,16 +350,16 @@ class ExtendedCaresTest extends SapphireTest
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
-            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
             // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
-            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
-            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
             // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
-            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];
     }
 

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -4,6 +4,9 @@ namespace Terraformers\KeysForCache\Tests\Scenarios;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\BaseCaredHasMany;
@@ -50,7 +53,10 @@ class ExtendedCaresTest extends SapphireTest
         PolymorphicCaredHasOne::class,
     ];
 
-    public function testCaresPureHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -58,27 +64,21 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(CaredBelongsTo::class, 'model1');
 
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testCaresBelongsTo(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -86,27 +86,21 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(CaredBelongsTo::class, 'model1');
 
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(CaredBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->CaredBelongsToID, $model->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testCaresHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -114,27 +108,21 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(CaredHasOne::class, 'model1');
 
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(CaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->CaredHasOneID, $model->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testPolymorphicCaresHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -142,27 +130,21 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicCaredHasOne::class, 'model1');
 
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(PolymorphicCaredHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testExtendedPolymorphicCaresHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testExtendedPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -170,27 +152,21 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
         $model = $this->objFromFixture(ExtendedPolymorphicCaredHasMany::class, 'model1');
 
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
+
         // Check that we're set up correctly
         $this->assertEquals(ExtendedPolymorphicCaredHasMany::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $originalKey = $page->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testCaresHasMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -198,22 +174,17 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(CaredHasMany::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testPolymorphicCaresHasMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -221,48 +192,40 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicCaredHasMany::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testExtendedPolymorphicCaresHasMany(): void
-    {
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testExtendedPolymorphicCaresHasMany(
+        string $readingMode,
+        string $saveMethod,
+        bool $expectMatch
+    ): void {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
 
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
         $model = $this->objFromFixture(ExtendedPolymorphicCaredHasMany::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($newKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
     /**
      * Testing that Base relationships work when the explicit class is used in the relationship
+     *
+     * @dataProvider readingModesWithSaveMethods
      */
-    public function testBaseCaredHasOne(): void
+    public function testBaseCaredHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -270,25 +233,19 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
         $model = $this->objFromFixture(BaseCaredHasOne::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
     /**
      * Testing that Base relationships work when the explicit class is used in the relationship
+     *
+     * @dataProvider readingModesWithSaveMethods
      */
-    public function testBaseCaredHasMany(): void
+    public function testBaseCaredHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -296,25 +253,19 @@ class ExtendedCaresTest extends SapphireTest
         $page = $this->objFromFixture(ExtendedCaresPage::class, 'page2');
         $model = $this->objFromFixture(BaseCaredHasMany::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
     /**
      * Now testing that a relationship to a Base class still works when the related object is an extended class
+     *
+     * @dataProvider readingModesWithSaveMethods
      */
-    public function testExtendedCaredHasOne(): void
+    public function testExtendedCaredHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -324,25 +275,19 @@ class ExtendedCaresTest extends SapphireTest
         // class extension that should also trigger an update
         $model = $this->objFromFixture(ExtendedCaredHasOne::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $model->forceChange();
-        $model->write();
-
-        $newKey = $page->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
     /**
      * Now testing that a relationship to a Base class still works when the related object is an extended class
+     *
+     * @dataProvider readingModesWithSaveMethods
      */
-    public function testExtendedCaredHasMany(): void
+    public function testExtendedCaredHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
         ProcessedUpdatesService::singleton()->flush();
@@ -352,19 +297,65 @@ class ExtendedCaresTest extends SapphireTest
         // class extension that should also trigger an update
         $model = $this->objFromFixture(ExtendedCaredHasMany::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+    }
 
-        $model->forceChange();
-        $model->write();
+    protected function assertCacheKeyChanges(
+        ExtendedCaresPage $page,
+        DataObject $model,
+        string $readingMode,
+        string $saveMethod,
+        bool $expectMatch
+    ): void {
+        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
+            Versioned::set_stage($readingMode);
 
-        $newKey = $page->getCacheKey();
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $originalKey = CacheKey::findInStage($page);
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+            $this->assertNotNull($originalKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
+
+            // Flush updates again before we trigger the next change
+            ProcessedUpdatesService::singleton()->flush();
+
+            $model->forceChange();
+            $model->{$saveMethod}();
+
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $newKey = CacheKey::findInStage($page);
+
+            $this->assertNotNull($newKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
+
+            if ($expectMatch) {
+                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+            } else {
+                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+            }
+        });
+    }
+
+    public function readingModesWithSaveMethods(): array
+    {
+        return [
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // stage of our CacheKey
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+        ];
     }
 
     protected function tearDown(): void

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -351,13 +351,13 @@ class ExtendedCaresTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -328,6 +328,9 @@ class ExtendedCaresTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $model->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $model->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -336,6 +339,7 @@ class ExtendedCaresTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($originalKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -54,7 +54,7 @@ class ExtendedTouchesTest extends SapphireTest
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasOne::class, 'model1');
@@ -67,13 +67,13 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertEquals(TouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->TouchedHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedBelongsTo::class, 'model1');
@@ -86,13 +86,13 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertEquals(TouchedBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->TouchedBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasOne::class, 'model1');
@@ -105,7 +105,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertEquals(PolymorphicTouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -114,7 +114,7 @@ class ExtendedTouchesTest extends SapphireTest
     public function testExtendedPolymorphicTouchesHasOne(
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page2');
         $model = $this->objFromFixture(ExtendedPolymorphicTouchedHasOne::class, 'model1');
@@ -127,13 +127,13 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertEquals(ExtendedPolymorphicTouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasMany::class, 'model1');
@@ -142,13 +142,13 @@ class ExtendedTouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasMany::class, 'model1');
@@ -157,7 +157,7 @@ class ExtendedTouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
@@ -166,7 +166,7 @@ class ExtendedTouchesTest extends SapphireTest
     public function testExtendedPolymorphicTouchesHasMany(
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page2');
         $model = $this->objFromFixture(ExtendedPolymorphicTouchedHasMany::class, 'model1');
@@ -175,13 +175,13 @@ class ExtendedTouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchedPage::class, 'page1');
         $model = $this->objFromFixture(TouchesBelongsTo::class, 'model1');
@@ -190,33 +190,35 @@ class ExtendedTouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates again before we trigger the next change
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-            $model->forceChange();
-            $model->{$saveMethod}();
+                $model->forceChange();
+                $model->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($newKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     protected function assertCacheKeyChanges(
@@ -224,35 +226,37 @@ class ExtendedTouchesTest extends SapphireTest
         DataObject $model,
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($model);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($model);
 
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates again before we trigger the next change
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-            $page->forceChange();
-            $page->{$saveMethod}();
+                $page->forceChange();
+                $page->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($model);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($model);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($newKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     public function readingModesWithSaveMethods(): array
@@ -260,16 +264,16 @@ class ExtendedTouchesTest extends SapphireTest
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
-            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
             // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
-            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
-            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
             // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
-            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];
     }
 

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -265,13 +265,13 @@ class ExtendedTouchesTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -204,6 +204,9 @@ class ExtendedTouchesTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $model->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $model->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -212,6 +215,7 @@ class ExtendedTouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {
@@ -242,6 +246,9 @@ class ExtendedTouchesTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $page->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $page->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -250,6 +257,7 @@ class ExtendedTouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {

--- a/tests/Scenarios/GlobalCaresTest.php
+++ b/tests/Scenarios/GlobalCaresTest.php
@@ -5,6 +5,8 @@ namespace Terraformers\KeysForCache\Tests\Scenarios;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SiteConfig\SiteConfig;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Pages\GlobalCaresPage;
@@ -21,29 +23,56 @@ class GlobalCaresTest extends SapphireTest
         GlobalCaresPage::class,
     ];
 
-    public function testGlobalCares(): void
+    /**
+     * @dataProvider readingModes
+     */
+    public function testGlobalCares(string $readingMode): void
     {
         $siteConfig = SiteConfig::current_site_config();
         $page = $this->objFromFixture(GlobalCaresPage::class, 'page1');
 
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
+        // Make sure our page is published
+        $page->publishRecursive();
 
-        // Check we're set up correctly
-        $originalKey = $page->getCacheKey();
+        Versioned::withVersionedMode(function () use ($page, $siteConfig, $readingMode): void {
+            Versioned::set_stage($readingMode);
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
+            // Check we're set up correctly
+            $originalKey = CacheKey::findInStage($page);
 
-        // Begin changes
-        $siteConfig->forceChange();
-        $siteConfig->write();
+            $this->assertNotNull($originalKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
 
-        $newKey = $page->getCacheKey();
+            // Updates are processed as part of scaffold, so we need to flush before we kick off
+            ProcessedUpdatesService::singleton()->flush();
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+            // Begin changes
+            $siteConfig->forceChange();
+            $siteConfig->write();
+
+            $newKey = CacheKey::findInStage($page);
+
+            // Global cares work by simply deleting the CacheKeys, so we would expect this to be null initially
+            $this->assertNull($newKey);
+
+            // Once we have run getCacheKey() we should have generated a new Key
+            $page->getCacheKey();
+
+            $newKey = CacheKey::findInStage($page);
+
+            // We would now expect it to exist
+            $this->assertNotNull($newKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
+            $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+        });
+    }
+
+    public function readingModes(): array
+    {
+        return [
+            [Versioned::DRAFT],
+            [Versioned::LIVE],
+        ];
     }
 
     protected function tearDown(): void

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -194,6 +194,9 @@ class TouchesTest extends SapphireTest
                 ProcessedUpdatesService::singleton()->flush();
 
                 $model->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $model->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -202,6 +205,7 @@ class TouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {
@@ -233,6 +237,9 @@ class TouchesTest extends SapphireTest
 
                 // Begin triggering changes
                 $page->forceChange();
+                // @see readingModesWithSaveMethods() - write() or publishRecursive() depending on the test
+                // We are performing this test across both reading modes, but we expect CacheKeys to respect the action,
+                // rather than the reading mode (that being, write() creates DRAFT, and publish() creates LIVE)
                 $page->{$saveMethod}();
 
                 // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
@@ -241,6 +248,7 @@ class TouchesTest extends SapphireTest
                 $this->assertNotNull($newKey);
                 $this->assertNotEmpty($newKey->KeyHash);
 
+                // @see readingModesWithSaveMethods() for when (and why) we expect changes to our KeyHash
                 if ($expectKeyChange) {
                     $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
                 } else {

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -46,7 +46,7 @@ class TouchesTest extends SapphireTest
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasOne::class, 'model1');
@@ -59,13 +59,13 @@ class TouchesTest extends SapphireTest
         $this->assertEquals(TouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->TouchedHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedBelongsTo::class, 'model1');
@@ -78,13 +78,13 @@ class TouchesTest extends SapphireTest
         $this->assertEquals(TouchedBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->TouchedBelongsToID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasOne::class, 'model1');
@@ -97,13 +97,13 @@ class TouchesTest extends SapphireTest
         $this->assertEquals(PolymorphicTouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasMany::class, 'model1');
@@ -112,13 +112,13 @@ class TouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasMany::class, 'model1');
@@ -127,13 +127,13 @@ class TouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesManyMany(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesManyMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedManyMany::class, 'model1');
@@ -146,13 +146,13 @@ class TouchesTest extends SapphireTest
         $this->assertCount(1, $page->TouchedManyMany());
         $this->assertEquals($model->ID, $page->TouchedManyMany()->first()->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesThrough(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesThrough(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedThrough::class, 'model1');
@@ -165,13 +165,13 @@ class TouchesTest extends SapphireTest
         $this->assertCount(1, $page->TouchedThrough());
         $this->assertEquals($model->ID, $page->TouchedThrough()->first()->ID);
 
-        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
     /**
      * @dataProvider readingModesWithSaveMethods
      */
-    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
+    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchedPage::class, 'page1');
         $model = $this->objFromFixture(TouchesBelongsTo::class, 'model1');
@@ -180,33 +180,35 @@ class TouchesTest extends SapphireTest
         $page->publishRecursive();
         $model->publishRecursive();
 
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates again before we trigger the next change
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-            $model->forceChange();
-            $model->{$saveMethod}();
+                $model->forceChange();
+                $model->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($page);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($page);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($newKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     protected function assertCacheKeyChanges(
@@ -214,36 +216,38 @@ class TouchesTest extends SapphireTest
         DataObject $model,
         string $readingMode,
         string $saveMethod,
-        bool $expectMatch
+        bool $expectKeyChange
     ): void {
-        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
-            Versioned::set_stage($readingMode);
+        Versioned::withVersionedMode(
+            function () use ($page, $model, $readingMode, $saveMethod, $expectKeyChange): void {
+                Versioned::set_stage($readingMode);
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $originalKey = CacheKey::findInStage($model);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $originalKey = CacheKey::findInStage($model);
 
-            $this->assertNotNull($originalKey);
-            $this->assertNotEmpty($originalKey->KeyHash);
+                $this->assertNotNull($originalKey);
+                $this->assertNotEmpty($originalKey->KeyHash);
 
-            // Flush updates again before we trigger the next change
-            ProcessedUpdatesService::singleton()->flush();
+                // Flush updates again before we trigger the next change
+                ProcessedUpdatesService::singleton()->flush();
 
-            // Begin triggering changes
-            $page->forceChange();
-            $page->{$saveMethod}();
+                // Begin triggering changes
+                $page->forceChange();
+                $page->{$saveMethod}();
 
-            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
-            $newKey = CacheKey::findInStage($model);
+                // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+                $newKey = CacheKey::findInStage($model);
 
-            $this->assertNotNull($newKey);
-            $this->assertNotEmpty($newKey->KeyHash);
+                $this->assertNotNull($newKey);
+                $this->assertNotEmpty($newKey->KeyHash);
 
-            if ($expectMatch) {
-                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
-            } else {
-                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                if ($expectKeyChange) {
+                    $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+                } else {
+                    $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+                }
             }
-        });
+        );
     }
 
     public function readingModesWithSaveMethods(): array
@@ -251,16 +255,16 @@ class TouchesTest extends SapphireTest
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
-            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
             // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
-            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
-            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
             // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
-            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];
     }
 

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -256,13 +256,13 @@ class TouchesTest extends SapphireTest
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
             'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', true],
-            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // If publishRecursive() is performed on a model, then we expect the same behaviour as above for the DRAFT
             // stage of our CacheKey
             'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', true],
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
             // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
             'performing write() in LIVE stage' => [Versioned::LIVE, 'write', false],
-            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // If publishRecursive() is performed on a model, then we expect that CacheKey to also be published. As we
             // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
             'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', true],
         ];

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -4,6 +4,9 @@ namespace Terraformers\KeysForCache\Tests\Scenarios;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use Terraformers\KeysForCache\Models\CacheKey;
 use Terraformers\KeysForCache\RelationshipGraph\Graph;
 use Terraformers\KeysForCache\Services\ProcessedUpdatesService;
 use Terraformers\KeysForCache\Tests\Mocks\Models\PolymorphicTouchedHasMany;
@@ -40,213 +43,225 @@ class TouchesTest extends SapphireTest
         TouchesBelongsTo::class,
     ];
 
-    public function testTouchesHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasOne::class, 'model1');
+
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
         // Check that we're set up correctly
         $this->assertEquals(TouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->TouchedHasOneID, $model->ID);
 
-        $originalKey = $model->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesTrueHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedBelongsTo::class, 'model1');
+
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
         // Check that we're set up correctly
         $this->assertEquals(TouchedBelongsTo::class, $model->ClassName);
         $this->assertEquals($page->TouchedBelongsToID, $model->ID);
 
-        $originalKey = $model->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testPolymorphicTouchesHasOne(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasOne::class, 'model1');
+
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
         // Check that we're set up correctly
         $this->assertEquals(PolymorphicTouchedHasOne::class, $model->ClassName);
         $this->assertEquals($page->PolymorphicHasOneID, $model->ID);
 
-        $originalKey = $model->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin changes
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesHasMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedHasMany::class, 'model1');
 
-        $originalKey = $model->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testPolymorphicTouchesHasMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(PolymorphicTouchedHasMany::class, 'model1');
 
-        $originalKey = $model->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesManyMany(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesManyMany(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedManyMany::class, 'model1');
+
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
         // Check we're set up correctly
         $this->assertCount(1, $page->TouchedManyMany());
         $this->assertEquals($model->ID, $page->TouchedManyMany()->first()->ID);
 
-        $originalKey = $model->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin triggering changes
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesThrough(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesThrough(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
         $model = $this->objFromFixture(TouchedThrough::class, 'model1');
+
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
         // Check we're set up correctly
         $this->assertCount(1, $page->TouchedThrough());
         $this->assertEquals($model->ID, $page->TouchedThrough()->first()->ID);
 
-        $originalKey = $model->getCacheKey();
-
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
-
-        // Begin triggering changes
-        $page->forceChange();
-        $page->write();
-
-        $newKey = $model->getCacheKey();
-
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+        $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectMatch);
     }
 
-    public function testTouchesBelongsTo(): void
+    /**
+     * @dataProvider readingModesWithSaveMethods
+     */
+    public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectMatch): void
     {
-        // Updates are processed as part of scaffold, so we need to flush before we kick off
-        ProcessedUpdatesService::singleton()->flush();
-
         $page = $this->objFromFixture(TouchedPage::class, 'page1');
         $model = $this->objFromFixture(TouchesBelongsTo::class, 'model1');
 
-        $originalKey = $page->getCacheKey();
+        // Make sure our models are published
+        $page->publishRecursive();
+        $model->publishRecursive();
 
-        $this->assertNotNull($originalKey);
-        $this->assertNotEmpty($originalKey);
+        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
+            Versioned::set_stage($readingMode);
 
-        $model->forceChange();
-        $model->write();
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $originalKey = CacheKey::findInStage($page);
 
-        $newKey = $page->getCacheKey();
+            $this->assertNotNull($originalKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
 
-        $this->assertNotNull($newKey);
-        $this->assertNotEmpty($originalKey);
-        $this->assertNotEquals($originalKey, $newKey);
+            // Flush updates again before we trigger the next change
+            ProcessedUpdatesService::singleton()->flush();
+
+            $model->forceChange();
+            $model->{$saveMethod}();
+
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $newKey = CacheKey::findInStage($page);
+
+            $this->assertNotNull($newKey);
+            $this->assertNotEmpty($newKey->KeyHash);
+
+            if ($expectMatch) {
+                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+            } else {
+                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+            }
+        });
+    }
+
+    protected function assertCacheKeyChanges(
+        TouchesPage $page,
+        DataObject $model,
+        string $readingMode,
+        string $saveMethod,
+        bool $expectMatch
+    ): void {
+        Versioned::withVersionedMode(function () use ($page, $model, $readingMode, $saveMethod, $expectMatch): void {
+            Versioned::set_stage($readingMode);
+
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $originalKey = CacheKey::findInStage($model);
+
+            $this->assertNotNull($originalKey);
+            $this->assertNotEmpty($originalKey->KeyHash);
+
+            // Flush updates again before we trigger the next change
+            ProcessedUpdatesService::singleton()->flush();
+
+            // Begin triggering changes
+            $page->forceChange();
+            $page->{$saveMethod}();
+
+            // Specifically fetching this way to make sure it's us fetching without any generation of KeyHash
+            $newKey = CacheKey::findInStage($model);
+
+            $this->assertNotNull($newKey);
+            $this->assertNotEmpty($newKey->KeyHash);
+
+            if ($expectMatch) {
+                $this->assertEquals($originalKey->KeyHash, $newKey->KeyHash);
+            } else {
+                $this->assertNotEquals($originalKey->KeyHash, $newKey->KeyHash);
+            }
+        });
+    }
+
+    public function readingModesWithSaveMethods(): array
+    {
+        return [
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
+            'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
+            // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
+            // stage of our CacheKey
+            'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
+            // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
+            // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
+            'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
+            // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
+            // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
+            'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
+        ];
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Fixes #62
Closes #62

Basically related to the discovery here:
https://github.com/silverstripe/silverstripe-versioned/issues/382

If a user/author/etc is in a `LIVE` reading mode then any `write()` (to any `Versioned` `DataObject`) is essentially a publish (just without the extension hooks being triggered).

The change here is to make sure that we always retrieve and `write()` our `CacheKeys` in the expected stage.

## Manual testing

So, for all of these, I just made my Page and Blocks output the value of `$CacheKey` into the template so that I could see what it was, and then I compared between `?stage=Stage` and `?stage=Live`.

**Test One:**

1. Publish page
2. View page in `?stage=Stage` and note CacheKey values
3. View page in `?stage=Live` and compare values
4. **Result:** As expected, they were the same

**Test Two:**

1. Make a change to the Page and save (not publish)
2. View page in `?stage=Stage` and note CacheKey values
3. View page in `?stage=Live` and compare values
4. **Result:** As expected, the `Stage` hashes had updated, and the `Live` hashes were the same
5. Publish page
6. View page in `?stage=Stage` and note CacheKey values
7. View page in `?stage=Live` and compare values
8. **Result:** As expected, the `Live` hashes match `Stage`

**Test Three:**

1. Delete all `CacheKey` records from all tables
2. View page in `?stage=Stage`
3. **Result:** As expected, there were records in the Draft and Versions tables, but no records in the Live table
2. View page in `?stage=Live`
3. **Result:** As expected, Live table was updated, and there were new "published" records in the Versions table

## Test coverage

So ah, yea, this got really large.

All of our scenarios now run between different stages, and some even perform different actions (`write()` vs `publishRecursive()` between those stages.

You'll see this data provider a lot. The explanation of what each test does, and what is expected, is hopefully described ok.

```php
public function readingModesWithSaveMethods(): array
{
    return [
        // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
        // we are working in the DRAFT stage, we would expect a different value when we fetch that CacheKey again
        'performing write() in DRAFT stage' => [Versioned::DRAFT, 'write', false],
        // If publishRecursive() is performed on a modal, then we expect the same behaviour as above for the DRAFT
        // stage of our CacheKey
        'performing publishRecursive() in DRAFT stage' => [Versioned::DRAFT, 'publishRecursive', false],
        // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since
        // we are working in the LIVE stage, we would expect the LIVE value of this CacheKey to be unchanged
        'performing write() in LIVE stage' => [Versioned::LIVE, 'write', true],
        // If publishRecursive() is performed on a modal, then we expect that CacheKey to also be published. As we
        // are working in the LIVE stage, we would now expect a new CacheKey value when it if fetched again
        'performing publishRecursive() in LIVE stage' => [Versioned::LIVE, 'publishRecursive', false],
    ];
}
```