### PR TITLE
Add error message if relationship is missing for dot notation

### DIFF
--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -309,12 +309,7 @@ class Graph implements Flushable
                     }
 
                     $careNode = $this->findOrCreateNode($careClassName);
-                    $edges[] = new Edge(
-                        $careNode,
-                        $node,
-                        $caresRelation,
-                        $relationType
-                    );
+                    $edges[] = new Edge($careNode, $node, $caresRelation, $relationType);
 
                     continue;
                 }

--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -292,12 +292,28 @@ class Graph implements Flushable
 
                 // A dot notation is available, so we can map this immediately and continue
                 if ($caresRelation) {
+                    $relationType = $this->getRelationType($careClassName, $caresRelation);
+
+                    if (!$relationType) {
+                        $errors[] = sprintf(
+                            'Dot notation %s provided for %s::%s, but no corresponding relationship found in %s.'
+                                . ' You might need to add a has_many, has_one, belongs_to, etc in %s',
+                            sprintf('%s.%s', $careClassName, $caresRelation),
+                            $className,
+                            $relation,
+                            $careClassName,
+                            $careClassName
+                        );
+
+                        continue;
+                    }
+
                     $careNode = $this->findOrCreateNode($careClassName);
                     $edges[] = new Edge(
                         $careNode,
                         $node,
                         $caresRelation,
-                        $this->getRelationType($careClassName, $caresRelation)
+                        $relationType
                     );
 
                     continue;


### PR DESCRIPTION
If you created a `cares` for a relationship with dot notation, EG:

```php
private static array $has_many = [
    'Links' => Link::class . '.MenuGroup',
];

private static array $cares = [
    'Links',
];
```

But there was no corresponding relationship on the other end (in this case, `Link::class` was missing a `has_one`), then an `getRelationType()` would return `null`, and `Edge::__construct()` would throw an unhelpful exception because `$relationType` must be `string`.