### PR TITLE
allow setting key to null

### DIFF
--- a/src/DataTransferObjects/CacheKeyDto.php
+++ b/src/DataTransferObjects/CacheKeyDto.php
@@ -13,7 +13,7 @@ class CacheKeyDto
         return $this->key;
     }
 
-    public function setKey(string $key): void
+    public function setKey(?string $key): void
     {
         $this->key = $key;
     }


### PR DESCRIPTION
currently even though `$this->key` is nullable, the setter cannot set the key to `null` because of the argument type