### PR TITLE
Silverstripe 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules
 /vendor/
 .DS_Store
 .idea
+.phpunit.result.cache
+app/
+composer.lock
+public/

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
         "silverstripe/framework": "^6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^11.5",
         "tractorcow/silverstripe-fluent": "^8",
-        "slevomat/coding-standard": "~8.8.0"
+        "slevomat/coding-standard": "~8.8.0",
+        "silverstripe/cms": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5"
+        "silverstripe/framework": "^6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "tractorcow/silverstripe-fluent": "^7",
+        "phpunit/phpunit": "^11",
+        "tractorcow/silverstripe-fluent": "^8",
         "slevomat/coding-standard": "~8.8.0"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,6 @@
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
 	<file>src</file>
-	<file>tests</file>
 
     <!-- Show progress and output sniff names on violation, and add colours -->
     <arg value="p" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="Default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
+  <testsuite name="Default">
+    <directory>tests/</directory>
+  </testsuite>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Extensions/CacheKeyExtension.php
+++ b/src/Extensions/CacheKeyExtension.php
@@ -3,10 +3,10 @@
 namespace Terraformers\KeysForCache\Extensions;
 
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordViewer;
-use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\Versioned\Versioned;
@@ -20,7 +20,7 @@ use Terraformers\KeysForCache\State\StagingState;
  * @property DataObject|Versioned|$this $owner
  * @method HasManyList|CacheKey CacheKeys()
  */
-class CacheKeyExtension extends DataExtension
+class CacheKeyExtension extends Extension
 {
     private static array $has_many = [
         // Programmatically we know that we will only ever create one of these CacheKey records per unique DataObject,

--- a/src/Extensions/FluentExtension.php
+++ b/src/Extensions/FluentExtension.php
@@ -2,11 +2,11 @@
 
 namespace Terraformers\KeysForCache\Extensions;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use Terraformers\KeysForCache\DataTransferObjects\CacheKeyDto;
 use TractorCow\Fluent\State\FluentState;
 
-class FluentExtension extends DataExtension
+class FluentExtension extends Extension
 {
     public function updateCacheKey(CacheKeyDto $cacheKey): void
     {

--- a/src/Extensions/StagingExtension.php
+++ b/src/Extensions/StagingExtension.php
@@ -3,13 +3,13 @@
 namespace Terraformers\KeysForCache\Extensions;
 
 use SilverStripe\CMS\Controllers\ContentController;
-use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Core\Extension;
 use Terraformers\KeysForCache\State\StagingState;
 
 /**
  * @property ContentController $owner
  */
-class StagingExtension extends SiteTreeExtension
+class StagingExtension extends Extension
 {
     public function contentcontrollerInit(ContentController $controller): void
     {

--- a/src/Models/CacheKey.php
+++ b/src/Models/CacheKey.php
@@ -2,8 +2,8 @@
 
 namespace Terraformers\KeysForCache\Models;
 
+use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationException;
 use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\Extensions\CacheKeyExtension;
 

--- a/src/RelationshipGraph/Graph.php
+++ b/src/RelationshipGraph/Graph.php
@@ -10,8 +10,8 @@ use SilverStripe\Core\Config\Config_ForClass;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\View\ViewableData;
 use Terraformers\KeysForCache\Models\CacheKey;
 
 class Graph implements Flushable
@@ -49,7 +49,7 @@ class Graph implements Flushable
         // Base classes that show up in every ancestry array
         $disallowList = [
             DataObject::class,
-            ViewableData::class,
+            ModelData::class,
         ];
 
         return array_filter(

--- a/src/Services/CacheProcessingService.php
+++ b/src/Services/CacheProcessingService.php
@@ -4,9 +4,9 @@ namespace Terraformers\KeysForCache\Services;
 
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Model\List\SS_List;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
 use Terraformers\KeysForCache\DataTransferObjects\EdgeUpdateDto;
 use Terraformers\KeysForCache\Models\CacheKey;

--- a/tests/Extensions/CacheKeyExtensionTest.php
+++ b/tests/Extensions/CacheKeyExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Terraformers\KeysForCache\Tests\Extensions;
 
 use Page;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Versioned\Versioned;
@@ -24,9 +25,7 @@ class CacheKeyExtensionTest extends SapphireTest
         CachePage::class,
     ];
 
-    /**
-     * @dataProvider readingModes
-     */
+    #[DataProvider('readingModes')]
     public function testWriteGeneratesCacheKey(string $readingMode): void
     {
         $page = Versioned::withVersionedMode(static function () use ($readingMode): CachePage {
@@ -64,9 +63,7 @@ class CacheKeyExtensionTest extends SapphireTest
         });
     }
 
-    /**
-     * @dataProvider readingModes
-     */
+    #[DataProvider('readingModes')]
     public function testWriteDoesNotGenerateCacheKey(string $readingMode): void
     {
         Versioned::withVersionedMode(function () use ($readingMode): void {

--- a/tests/Extensions/CacheKeyExtensionTest.php
+++ b/tests/Extensions/CacheKeyExtensionTest.php
@@ -472,7 +472,7 @@ class CacheKeyExtensionTest extends SapphireTest
         );
     }
 
-    public function readingModes(): array
+    public static function readingModes(): array
     {
         return [
             [Versioned::DRAFT],

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -47,9 +48,7 @@ class CaresTest extends SapphireTest
         PolymorphicCaredHasMany::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -69,9 +68,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -91,9 +88,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -113,9 +108,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModes
-     */
+    #[DataProvider('readingModes')]
     public function testCaresHasOneNonVersioned(string $readingMode): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -157,9 +150,7 @@ class CaresTest extends SapphireTest
         });
     }
 
-    /**
-     * @dataProvider readingModes
-     */
+    #[DataProvider('readingModes')]
     public function testCaresHasOneVersionedNonStaged(string $readingMode): void
     {
         $page = $this->objFromFixture(CaresPage::class, 'page1');
@@ -198,9 +189,7 @@ class CaresTest extends SapphireTest
         });
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -220,9 +209,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -238,9 +225,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -256,9 +241,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testManyMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -278,9 +261,7 @@ class CaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testManyManyThrough(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off

--- a/tests/Scenarios/CaresTest.php
+++ b/tests/Scenarios/CaresTest.php
@@ -372,7 +372,7 @@ class CaresTest extends SapphireTest
         );
     }
 
-    public function readingModes(): array
+    public static function readingModes(): array
     {
         return [
             [Versioned::DRAFT],
@@ -380,7 +380,7 @@ class CaresTest extends SapphireTest
         ];
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -29,9 +30,7 @@ class DotNotationCaresTest extends SapphireTest
         DotNotationCaredHasOne::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -55,9 +54,7 @@ class DotNotationCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -122,9 +119,7 @@ class DotNotationCaresTest extends SapphireTest
         );
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -148,9 +143,7 @@ class DotNotationCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off

--- a/tests/Scenarios/DotNotationCaresTest.php
+++ b/tests/Scenarios/DotNotationCaresTest.php
@@ -242,7 +242,7 @@ class DotNotationCaresTest extends SapphireTest
         );
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -247,7 +247,7 @@ class DotNotationTouchesTest extends SapphireTest
         );
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since

--- a/tests/Scenarios/DotNotationTouchesTest.php
+++ b/tests/Scenarios/DotNotationTouchesTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -33,9 +34,7 @@ class DotNotationTouchesTest extends SapphireTest
         DotNotationTouchesBelongsTo::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -59,9 +58,7 @@ class DotNotationTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -85,9 +82,7 @@ class DotNotationTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -111,9 +106,7 @@ class DotNotationTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $modelOne, $modelTwo, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -53,9 +54,7 @@ class ExtendedCaresTest extends SapphireTest
         PolymorphicCaredHasOne::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresPureHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -75,9 +74,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -97,9 +94,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -119,9 +114,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicCaresHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -141,9 +134,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedPolymorphicCaresHasOne(
         string $readingMode,
         string $saveMethod,
@@ -166,9 +157,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -184,9 +173,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicCaresHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -202,9 +189,7 @@ class ExtendedCaresTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedPolymorphicCaresHasMany(
         string $readingMode,
         string $saveMethod,
@@ -225,9 +210,8 @@ class ExtendedCaresTest extends SapphireTest
 
     /**
      * Testing that Base relationships work when the explicit class is used in the relationship
-     *
-     * @dataProvider readingModesWithSaveMethods
      */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testBaseCaredHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -245,9 +229,8 @@ class ExtendedCaresTest extends SapphireTest
 
     /**
      * Testing that Base relationships work when the explicit class is used in the relationship
-     *
-     * @dataProvider readingModesWithSaveMethods
      */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testBaseCaredHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -265,9 +248,8 @@ class ExtendedCaresTest extends SapphireTest
 
     /**
      * Now testing that a relationship to a Base class still works when the related object is an extended class
-     *
-     * @dataProvider readingModesWithSaveMethods
      */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedCaredHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off
@@ -287,9 +269,8 @@ class ExtendedCaresTest extends SapphireTest
 
     /**
      * Now testing that a relationship to a Base class still works when the related object is an extended class
-     *
-     * @dataProvider readingModesWithSaveMethods
      */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedCaredHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         // Updates are processed as part of scaffold, so we need to flush before we kick off

--- a/tests/Scenarios/ExtendedCaresTest.php
+++ b/tests/Scenarios/ExtendedCaresTest.php
@@ -349,7 +349,7 @@ class ExtendedCaresTest extends SapphireTest
         );
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -51,9 +52,7 @@ class ExtendedTouchesTest extends SapphireTest
         TouchesBelongsTo::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
@@ -70,9 +69,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
@@ -89,9 +86,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
@@ -108,9 +103,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedPolymorphicTouchesHasOne(
         string $readingMode,
         string $saveMethod,
@@ -130,9 +123,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
@@ -145,9 +136,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchesPage::class, 'page1');
@@ -160,9 +149,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testExtendedPolymorphicTouchesHasMany(
         string $readingMode,
         string $saveMethod,
@@ -178,9 +165,7 @@ class ExtendedTouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(ExtendedTouchedPage::class, 'page1');

--- a/tests/Scenarios/ExtendedTouchesTest.php
+++ b/tests/Scenarios/ExtendedTouchesTest.php
@@ -267,7 +267,7 @@ class ExtendedTouchesTest extends SapphireTest
         );
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since

--- a/tests/Scenarios/GlobalCaresTest.php
+++ b/tests/Scenarios/GlobalCaresTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SiteConfig\SiteConfig;
@@ -23,9 +24,7 @@ class GlobalCaresTest extends SapphireTest
         GlobalCaresPage::class,
     ];
 
-    /**
-     * @dataProvider readingModes
-     */
+    #[DataProvider('readingModes')]
     public function testGlobalCares(string $readingMode): void
     {
         $siteConfig = SiteConfig::current_site_config();
@@ -67,7 +66,7 @@ class GlobalCaresTest extends SapphireTest
         });
     }
 
-    public function readingModes(): array
+    public static function readingModes(): array
     {
         return [
             [Versioned::DRAFT],

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -2,6 +2,7 @@
 
 namespace Terraformers\KeysForCache\Tests\Scenarios;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
@@ -43,9 +44,7 @@ class TouchesTest extends SapphireTest
         TouchesBelongsTo::class,
     ];
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -62,9 +61,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesTrueHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -81,9 +78,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicTouchesHasOne(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -100,9 +95,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -115,9 +108,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testPolymorphicTouchesHasMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -130,9 +121,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesManyMany(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -149,9 +138,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesThrough(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchesPage::class, 'page1');
@@ -168,9 +155,7 @@ class TouchesTest extends SapphireTest
         $this->assertCacheKeyChanges($page, $model, $readingMode, $saveMethod, $expectKeyChange);
     }
 
-    /**
-     * @dataProvider readingModesWithSaveMethods
-     */
+    #[DataProvider('readingModesWithSaveMethods')]
     public function testTouchesBelongsTo(string $readingMode, string $saveMethod, bool $expectKeyChange): void
     {
         $page = $this->objFromFixture(TouchedPage::class, 'page1');

--- a/tests/Scenarios/TouchesTest.php
+++ b/tests/Scenarios/TouchesTest.php
@@ -258,7 +258,7 @@ class TouchesTest extends SapphireTest
         );
     }
 
-    public function readingModesWithSaveMethods(): array
+    public static function readingModesWithSaveMethods(): array
     {
         return [
             // If write() is performed on a model then we would expect the CacheKey to be updated in DRAFT only. Since


### PR DESCRIPTION
This PR replaces deprecated Sillverstripe classes with their new namespaces.

It also updates the PHPUnit  to version 11 to be in-step with the CMS. This includes a number of changes such as data providers needing to be static and annotations uses rather than @metaData.

Tests passing locally on a SS6 install. Cursory functional testing is good (tested key generation on some pages, and global cares on SiteConfig)